### PR TITLE
mutate_form_model add_group: reject Table up-front; accept top-level …

### DIFF
--- a/bundles/com.codepilot1c.core.tests/src/com/codepilot1c/core/edt/metadata/FormGroupTypeIntentTest.java
+++ b/bundles/com.codepilot1c.core.tests/src/com/codepilot1c/core/edt/metadata/FormGroupTypeIntentTest.java
@@ -1,0 +1,174 @@
+package com.codepilot1c.core.edt.metadata;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.junit.Test;
+
+/**
+ * Tests for {@link FormGroupTypeIntent}.
+ *
+ * <p>Covers the BF-8908 Gap 3 hardening: distinguish requests that should
+ * proceed via the existing {@code add_group} dispatcher (PAGES, PAGE,
+ * COLUMN_GROUP, ...) from requests that ask for {@code Table} — which is
+ * a distinct EMF model class and must be rejected up-front to prevent
+ * silent downgrade to UsualGroup.</p>
+ */
+public class FormGroupTypeIntentTest {
+
+    // --- classify -----------------------------------------------------------
+
+    @Test
+    public void classifyTable_recognizesAllSeparatorVariants() {
+        assertEquals(FormGroupTypeIntent.Verdict.TABLE_NOT_A_GROUP,
+                FormGroupTypeIntent.classify("TABLE")); //$NON-NLS-1$
+        assertEquals(FormGroupTypeIntent.Verdict.TABLE_NOT_A_GROUP,
+                FormGroupTypeIntent.classify("Table")); //$NON-NLS-1$
+        assertEquals(FormGroupTypeIntent.Verdict.TABLE_NOT_A_GROUP,
+                FormGroupTypeIntent.classify("table")); //$NON-NLS-1$
+        assertEquals(FormGroupTypeIntent.Verdict.TABLE_NOT_A_GROUP,
+                FormGroupTypeIntent.classify("FormTable")); //$NON-NLS-1$
+        assertEquals(FormGroupTypeIntent.Verdict.TABLE_NOT_A_GROUP,
+                FormGroupTypeIntent.classify("data-table")); //$NON-NLS-1$
+        assertEquals(FormGroupTypeIntent.Verdict.TABLE_NOT_A_GROUP,
+                FormGroupTypeIntent.classify(" TABLE ")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void classify_recognizesPagesAndPageAsValidGroupTypes() {
+        // PAGES and PAGE *are* genuine ManagedFormGroupType enum values
+        // (FormGroup variants); they should NOT be rejected like Table.
+        assertEquals(FormGroupTypeIntent.Verdict.RECOGNIZED_GROUP_TYPE,
+                FormGroupTypeIntent.classify("PAGES")); //$NON-NLS-1$
+        assertEquals(FormGroupTypeIntent.Verdict.RECOGNIZED_GROUP_TYPE,
+                FormGroupTypeIntent.classify("Pages")); //$NON-NLS-1$
+        assertEquals(FormGroupTypeIntent.Verdict.RECOGNIZED_GROUP_TYPE,
+                FormGroupTypeIntent.classify("PAGE")); //$NON-NLS-1$
+        assertEquals(FormGroupTypeIntent.Verdict.RECOGNIZED_GROUP_TYPE,
+                FormGroupTypeIntent.classify("page")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void classify_recognizesOtherFormGroupTypes() {
+        assertEquals(FormGroupTypeIntent.Verdict.RECOGNIZED_GROUP_TYPE,
+                FormGroupTypeIntent.classify("USUAL_GROUP")); //$NON-NLS-1$
+        assertEquals(FormGroupTypeIntent.Verdict.RECOGNIZED_GROUP_TYPE,
+                FormGroupTypeIntent.classify("UsualGroup")); //$NON-NLS-1$
+        assertEquals(FormGroupTypeIntent.Verdict.RECOGNIZED_GROUP_TYPE,
+                FormGroupTypeIntent.classify("COLUMN_GROUP")); //$NON-NLS-1$
+        assertEquals(FormGroupTypeIntent.Verdict.RECOGNIZED_GROUP_TYPE,
+                FormGroupTypeIntent.classify("BUTTON_GROUP")); //$NON-NLS-1$
+        assertEquals(FormGroupTypeIntent.Verdict.RECOGNIZED_GROUP_TYPE,
+                FormGroupTypeIntent.classify("COMMAND_BAR")); //$NON-NLS-1$
+        assertEquals(FormGroupTypeIntent.Verdict.RECOGNIZED_GROUP_TYPE,
+                FormGroupTypeIntent.classify("AUTO_COMMAND_BAR")); //$NON-NLS-1$
+        assertEquals(FormGroupTypeIntent.Verdict.RECOGNIZED_GROUP_TYPE,
+                FormGroupTypeIntent.classify("POPUP")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void classify_unspecifiedForNullOrBlank() {
+        assertEquals(FormGroupTypeIntent.Verdict.UNSPECIFIED,
+                FormGroupTypeIntent.classify(null));
+        assertEquals(FormGroupTypeIntent.Verdict.UNSPECIFIED,
+                FormGroupTypeIntent.classify("")); //$NON-NLS-1$
+        assertEquals(FormGroupTypeIntent.Verdict.UNSPECIFIED,
+                FormGroupTypeIntent.classify("   ")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void classify_unrecognizedForRandomString() {
+        assertEquals(FormGroupTypeIntent.Verdict.UNRECOGNIZED,
+                FormGroupTypeIntent.classify("WIDGET")); //$NON-NLS-1$
+        assertEquals(FormGroupTypeIntent.Verdict.UNRECOGNIZED,
+                FormGroupTypeIntent.classify("SOMETHING_ELSE")); //$NON-NLS-1$
+    }
+
+    // --- extractRawType -----------------------------------------------------
+
+    @Test
+    public void extractRawType_priority_groupTypeBeatsTopLevelTypeBeatsSetType() {
+        Map<String, Object> operation = new LinkedHashMap<>();
+        operation.put("group_type", "PAGES"); //$NON-NLS-1$ //$NON-NLS-2$
+        operation.put("type", "PAGE"); //$NON-NLS-1$ //$NON-NLS-2$
+        Map<String, Object> set = Map.of("type", "USUAL_GROUP"); //$NON-NLS-1$ //$NON-NLS-2$
+
+        assertEquals("PAGES", FormGroupTypeIntent.extractRawType(operation, set)); //$NON-NLS-1$
+    }
+
+    @Test
+    public void extractRawType_topLevelTypeUsedWhenGroupTypeMissing() {
+        // BF-8908 repro: agent sent {"op":"add_group","type":"PAGES"} with no
+        // group_type and no nested set.  Until this fix the resolver only
+        // checked group_type and set.type, so PAGES silently fell back to
+        // USUAL_GROUP.  Verify extractRawType now picks it up.
+        Map<String, Object> operation = new LinkedHashMap<>();
+        operation.put("type", "PAGES"); //$NON-NLS-1$ //$NON-NLS-2$
+
+        assertEquals("PAGES", FormGroupTypeIntent.extractRawType(operation, Map.of())); //$NON-NLS-1$
+    }
+
+    @Test
+    public void extractRawType_setTypeUsedAsFinalFallback() {
+        Map<String, Object> set = Map.of("type", "PAGE"); //$NON-NLS-1$ //$NON-NLS-2$
+
+        assertEquals("PAGE", FormGroupTypeIntent.extractRawType(Map.of(), set)); //$NON-NLS-1$
+    }
+
+    @Test
+    public void extractRawType_nullWhenAllPositionsEmpty() {
+        assertNull(FormGroupTypeIntent.extractRawType(Map.of(), Map.of()));
+        assertNull(FormGroupTypeIntent.extractRawType(null, null));
+    }
+
+    @Test
+    public void extractRawType_caseInsensitiveKeys() {
+        Map<String, Object> operation = new LinkedHashMap<>();
+        operation.put("Group_Type", "PAGES"); //$NON-NLS-1$ //$NON-NLS-2$
+
+        assertEquals("PAGES", FormGroupTypeIntent.extractRawType(operation, Map.of())); //$NON-NLS-1$
+    }
+
+    @Test
+    public void extractRawType_blankValuesIgnored() {
+        Map<String, Object> operation = new LinkedHashMap<>();
+        operation.put("group_type", "  "); //$NON-NLS-1$ //$NON-NLS-2$
+        operation.put("type", "PAGES"); //$NON-NLS-1$ //$NON-NLS-2$
+
+        assertEquals("PAGES", FormGroupTypeIntent.extractRawType(operation, Map.of())); //$NON-NLS-1$
+    }
+
+    // --- tableNotAGroupMessage ----------------------------------------------
+
+    @Test
+    public void tableMessage_echoesValueAndPointsToFormXmlEdit() {
+        String msg = FormGroupTypeIntent.tableNotAGroupMessage("TABLE", "PricingTable"); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("must echo raw type:\n" + msg, msg.contains("'TABLE'")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("must echo group name:\n" + msg, msg.contains("PricingTable")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("must mention xsi:type=\"form:Table\":\n" + msg, //$NON-NLS-1$
+                msg.contains("xsi:type=\"form:Table\"")); //$NON-NLS-1$
+        assertTrue("must mention silent downgrade to UsualGroup:\n" + msg, //$NON-NLS-1$
+                msg.contains("UsualGroup")); //$NON-NLS-1$
+        assertTrue("must mention add_table op as the future path:\n" + msg, //$NON-NLS-1$
+                msg.contains("add_table")); //$NON-NLS-1$
+        assertTrue("must mention .form XML / Edit/Write workaround:\n" + msg, //$NON-NLS-1$
+                msg.contains(".form") && msg.contains("Edit/Write")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("must mention inspect_form_layout for verification:\n" + msg, //$NON-NLS-1$
+                msg.contains("inspect_form_layout")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void tableMessage_omitsGroupNameWhenBlank() {
+        String msg = FormGroupTypeIntent.tableNotAGroupMessage("TABLE", null); //$NON-NLS-1$
+        assertFalse("must not include name='' marker when name is null:\n" + msg, //$NON-NLS-1$
+                msg.contains("name=''")); //$NON-NLS-1$
+        msg = FormGroupTypeIntent.tableNotAGroupMessage("TABLE", " "); //$NON-NLS-1$ //$NON-NLS-2$
+        assertFalse("must not include name='' marker when name is blank:\n" + msg, //$NON-NLS-1$
+                msg.contains("name=''")); //$NON-NLS-1$
+    }
+}

--- a/bundles/com.codepilot1c.core/src/com/codepilot1c/core/edt/metadata/EdtMetadataService.java
+++ b/bundles/com.codepilot1c.core/src/com/codepilot1c/core/edt/metadata/EdtMetadataService.java
@@ -813,6 +813,7 @@ public class EdtMetadataService {
                                 "Invalid group name: " + name, false); //$NON-NLS-1$
                     }
                     Map<String, Object> set = asMap(operation.get("set")); //$NON-NLS-1$
+                    rejectTableAsAddGroupType(operation, set, name);
                     ManagedFormGroupType groupType = resolveRequestedGroupType(operation, set);
                     Integer index = asOptionalInteger(operation.get("index"), "index"); //$NON-NLS-1$ //$NON-NLS-2$
                     FormGroup group = addGroupItem(
@@ -1200,9 +1201,17 @@ public class EdtMetadataService {
     }
 
     private ManagedFormGroupType resolveRequestedGroupType(Map<String, Object> operation, Map<String, Object> set) {
+        // Look at all three commonly-used positions in priority order:
+        // group_type (most specific), top-level type, set.type (legacy).
         Object rawType = hasMapKeyIgnoreCase(operation, "group_type") //$NON-NLS-1$
                 ? getMapValueIgnoreCase(operation, "group_type") //$NON-NLS-1$
-                : getMapValueIgnoreCase(set, "type"); //$NON-NLS-1$
+                : null;
+        if (rawType == null) {
+            rawType = getMapValueIgnoreCase(operation, "type"); //$NON-NLS-1$
+        }
+        if (rawType == null) {
+            rawType = getMapValueIgnoreCase(set, "type"); //$NON-NLS-1$
+        }
         if (rawType instanceof ManagedFormGroupType groupType) {
             return groupType;
         }
@@ -1215,6 +1224,32 @@ public class EdtMetadataService {
             }
         }
         return ManagedFormGroupType.USUAL_GROUP;
+    }
+
+    /**
+     * Pre-flight reject {@code add_group type:"TABLE"} (and aliases).  Table
+     * is a distinct EMF model class, not a FormGroup variant, so the
+     * historical fallback to USUAL_GROUP silently produced a UsualGroup
+     * pretending to be a Table.  Until mutate_form_model grows a dedicated
+     * {@code add_table} op, fail fast with an actionable hint pointing the
+     * agent at direct .form XML editing.
+     */
+    private void rejectTableAsAddGroupType(
+            Map<String, Object> operation,
+            Map<String, Object> set,
+            String groupName
+    ) {
+        String rawType = FormGroupTypeIntent.extractRawType(operation, set);
+        if (rawType == null) {
+            return;
+        }
+        FormGroupTypeIntent.Verdict verdict = FormGroupTypeIntent.classify(rawType);
+        if (verdict == FormGroupTypeIntent.Verdict.TABLE_NOT_A_GROUP) {
+            throw new MetadataOperationException(
+                    MetadataOperationCode.INVALID_METADATA_CHANGE,
+                    FormGroupTypeIntent.tableNotAGroupMessage(rawType, groupName),
+                    false);
+        }
     }
 
     private Map<String, Object> stripMapKeysIgnoreCase(Map<String, Object> source, String... keysToRemove) {

--- a/bundles/com.codepilot1c.core/src/com/codepilot1c/core/edt/metadata/FormGroupTypeIntent.java
+++ b/bundles/com.codepilot1c.core/src/com/codepilot1c/core/edt/metadata/FormGroupTypeIntent.java
@@ -1,0 +1,175 @@
+package com.codepilot1c.core.edt.metadata;
+
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Pure-Java helpers for interpreting {@code type} / {@code group_type}
+ * values that callers pass to {@code mutate_form_model.add_group}.
+ *
+ * <p>Background: in the 1C form model, {@code Table}, {@code Pages}, and
+ * {@code Page} are <em>different things</em>:</p>
+ * <ul>
+ *   <li>{@code Pages} and {@code Page} are FormGroup variants — the EMF
+ *       enum {@code ManagedFormGroupType} exposes them as {@code PAGES}
+ *       and {@code PAGE}, and the XML serialization is
+ *       {@code <items xsi:type="form:FormGroup"><type>Pages</type>...} with
+ *       the appropriate {@code PagesGroupExtInfo}/{@code PageGroupExtInfo}
+ *       companions.  These can be created via the existing
+ *       {@code add_group} dispatcher once the user picks a recognized
+ *       enum value.</li>
+ *   <li>{@code Table} is its own EMF model class, NOT a FormGroup variant.
+ *       The XML serialization is {@code <items xsi:type="form:Table">...}
+ *       with a {@code TableExtInfo} block.  {@code add_group type:"TABLE"}
+ *       previously fell through to the {@code USUAL_GROUP} default and
+ *       produced a UsualGroup that <em>looked</em> created — only runtime
+ *       UI inspection or {@code inspect_form_layout} caught the silent
+ *       downgrade.</li>
+ * </ul>
+ *
+ * <p>This helper recognizes the three intents and returns a verdict the
+ * caller uses to either dispatch normally or throw a clear error.</p>
+ */
+public final class FormGroupTypeIntent {
+
+    /**
+     * Possible classifications of a {@code type}/{@code group_type} value
+     * supplied to {@code add_group}.
+     */
+    public enum Verdict {
+        /** No type expressed — caller should fall back to the default. */
+        UNSPECIFIED,
+        /** Caller asked for a Table, which is NOT a FormGroup variant. */
+        TABLE_NOT_A_GROUP,
+        /** Caller used a recognized {@code ManagedFormGroupType} enum value. */
+        RECOGNIZED_GROUP_TYPE,
+        /** Caller used a value that does not match any recognized intent. */
+        UNRECOGNIZED
+    }
+
+    /** Tokens that map to the Table EMF class (not a FormGroup variant). */
+    private static final Set<String> TABLE_TOKENS = Set.of(
+            "TABLE", //$NON-NLS-1$
+            "FORMTABLE", //$NON-NLS-1$
+            "DATATABLE"); //$NON-NLS-1$
+
+    /**
+     * Tokens (post-normalization) that match {@link
+     * com._1c.g5.v8.dt.form.model.ManagedFormGroupType} enum values.
+     * Normalization strips both {@code _} and {@code -}, so we list each
+     * canonical name without separators.  The {@code EdtMetadataService}
+     * resolver feeds the original raw value to {@code valueOf}, so the
+     * underscore-bearing form remains the source of truth there — this
+     * set only governs the verdict for the up-front classifier.
+     */
+    private static final Set<String> KNOWN_GROUP_TYPE_TOKENS = Set.of(
+            "USUALGROUP", //$NON-NLS-1$
+            "PAGES", //$NON-NLS-1$
+            "PAGE", //$NON-NLS-1$
+            "COLUMNGROUP", //$NON-NLS-1$
+            "BUTTONGROUP", //$NON-NLS-1$
+            "COMMANDBAR", //$NON-NLS-1$
+            "AUTOCOMMANDBAR", //$NON-NLS-1$
+            "POPUP", //$NON-NLS-1$
+            "CONTEXTMENU", //$NON-NLS-1$
+            "NAVIGATOR", //$NON-NLS-1$
+            "ROWACTIONSPANEL", //$NON-NLS-1$
+            "SELECTEDITEMSACTIONSPANEL"); //$NON-NLS-1$
+
+    private FormGroupTypeIntent() {
+    }
+
+    /**
+     * Classify a raw {@code type}/{@code group_type} string from the
+     * operation payload.
+     *
+     * @param rawValue caller-supplied string (may be null/blank)
+     * @return verdict — see {@link Verdict}
+     */
+    public static Verdict classify(String rawValue) {
+        if (rawValue == null) {
+            return Verdict.UNSPECIFIED;
+        }
+        String normalized = normalize(rawValue);
+        if (normalized.isEmpty()) {
+            return Verdict.UNSPECIFIED;
+        }
+        if (TABLE_TOKENS.contains(normalized)) {
+            return Verdict.TABLE_NOT_A_GROUP;
+        }
+        if (KNOWN_GROUP_TYPE_TOKENS.contains(normalized)) {
+            return Verdict.RECOGNIZED_GROUP_TYPE;
+        }
+        return Verdict.UNRECOGNIZED;
+    }
+
+    /**
+     * Resolve the raw type-string from an {@code add_group} operation,
+     * looking at all three commonly-used positions in priority order:
+     * {@code group_type} (most specific), top-level {@code type},
+     * {@code set.type} (legacy nested form).  Case-insensitive.  Returns
+     * null when none is set.
+     */
+    public static String extractRawType(Map<String, Object> operation, Map<String, Object> set) {
+        String value = caseInsensitiveString(operation, "group_type"); //$NON-NLS-1$
+        if (value != null) {
+            return value;
+        }
+        value = caseInsensitiveString(operation, "type"); //$NON-NLS-1$
+        if (value != null) {
+            return value;
+        }
+        return caseInsensitiveString(set, "type"); //$NON-NLS-1$
+    }
+
+    /**
+     * Build the agent-facing rejection message for the
+     * {@link Verdict#TABLE_NOT_A_GROUP} case.  Keeping the wording in one
+     * place makes it easy to assert on in tests and to keep agent-facing
+     * language consistent.
+     *
+     * @param rawValue the original {@code type} string (echoed back verbatim)
+     * @param groupName the {@code name} of the requested group, may be null
+     * @return human-readable message
+     */
+    public static String tableNotAGroupMessage(String rawValue, String groupName) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("add_group type='").append(rawValue).append("' is not supported"); //$NON-NLS-1$ //$NON-NLS-2$
+        if (groupName != null && !groupName.isBlank()) {
+            sb.append(" (name='").append(groupName).append("')"); //$NON-NLS-1$ //$NON-NLS-2$
+        }
+        sb.append(": Table is a distinct form element type (xsi:type=\"form:Table\")," //$NON-NLS-1$
+                + " not a FormGroup variant — emitting it from add_group" //$NON-NLS-1$
+                + " would silently downgrade to UsualGroup. Until mutate_form_model" //$NON-NLS-1$
+                + " grows a dedicated add_table op, edit the Form.form XML directly" //$NON-NLS-1$
+                + " (Edit/Write tools) using the Table block from a sibling form as" //$NON-NLS-1$
+                + " a template, then run inspect_form_layout to confirm" //$NON-NLS-1$
+                + " kind=\"Table\"."); //$NON-NLS-1$
+        return sb.toString();
+    }
+
+    private static String normalize(String value) {
+        return value
+                .replace("_", "") //$NON-NLS-1$ //$NON-NLS-2$
+                .replace("-", "") //$NON-NLS-1$ //$NON-NLS-2$
+                .replace(" ", "") //$NON-NLS-1$ //$NON-NLS-2$
+                .trim()
+                .toUpperCase(Locale.ROOT);
+    }
+
+    private static String caseInsensitiveString(Map<String, Object> map, String key) {
+        if (map == null || map.isEmpty() || key == null) {
+            return null;
+        }
+        for (Map.Entry<String, Object> entry : map.entrySet()) {
+            if (entry.getKey() != null && entry.getKey().equalsIgnoreCase(key) && entry.getValue() != null) {
+                String s = String.valueOf(entry.getValue()).trim();
+                if (!s.isBlank()) {
+                    return s;
+                }
+            }
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
…type for Pages/Page

Background
----------
The 1C form model treats Pages/Page and Table differently:

  * Pages/Page are FormGroup variants — the EMF enum ManagedFormGroupType has PAGES and PAGE values; the XML serialization is <items xsi:type="form:FormGroup"><type>Pages</type>...</items> plus the right PagesGroupExtInfo/PageGroupExtInfo companion.

  * Table is its own EMF model class, NOT a FormGroup variant — the XML is <items xsi:type="form:Table">...</items> with TableExtInfo.

Two issues compounded in BF-8908:

  1. resolveRequestedGroupType only looked at operation.group_type and set.type.  When the agent sent {"op":"add_group","name":"BFPages","type":"PAGES"} the top-level "type" field was ignored, so PAGES silently fell back to USUAL_GROUP.

  2. add_group type:"TABLE" exercised the same fallback for the wrong reason: TABLE is not a ManagedFormGroupType enum value at all, so the catch-IllegalArgumentException-and-default path produced a UsualGroup that *looked* like a Table to the agent.  Only inspect_form_layout exposed the silent downgrade.


Fix
---
- Add FormGroupTypeIntent — a pure-Java helper that classifies a raw type-string into UNSPECIFIED / TABLE_NOT_A_GROUP / RECOGNIZED_GROUP_TYPE / UNRECOGNIZED, plus an extractRawType helper that walks the three payload positions (group_type, top-level type, set.type) in priority order with case-insensitive key lookup.
- EdtMetadataService.applyFormModelOperations now:
    * resolveRequestedGroupType reads top-level "type" too (the field Pages/Page agents naturally send), in addition to group_type and set.type.  Pages/Page therefore stop silently downgrading.
    * rejectTableAsAddGroupType runs immediately after the name validation in case "addgroup".  When the requested type classifies as TABLE_NOT_A_GROUP, fail fast with an actionable message: "add_group type='TABLE' is not supported (name='PricingTable'): Table is a distinct form element type (xsi:type=\"form:Table\"), not a FormGroup variant — emitting it from add_group would silently downgrade to UsualGroup. Until mutate_form_model grows a dedicated add_table op, edit the Form.form XML directly (Edit/Write tools) using the Table block from a sibling form as a template, then run inspect_form_layout to confirm kind=\"Table\"."

Tests
-----
FormGroupTypeIntentTest pins:
- TABLE recognized through every common separator/case variant (TABLE, Table, table, FormTable, "data-table", " TABLE ")
- PAGES, PAGE, USUAL_GROUP, COLUMN_GROUP, BUTTON_GROUP, COMMAND_BAR, AUTO_COMMAND_BAR, POPUP all classify as RECOGNIZED_GROUP_TYPE
- null/blank inputs return UNSPECIFIED, random tokens UNRECOGNIZED
- extractRawType respects priority order (group_type wins over top-level type wins over set.type), is case-insensitive on keys, ignores blank values, returns null when nothing usable
- rejection message echoes the raw type, names the group, mentions xsi:type="form:Table", warns about silent downgrade to UsualGroup, points at the future add_table op, suggests the Edit/Write workaround, and references inspect_form_layout for verification

Note that this PR does NOT add native Table creation — that is a larger piece of work that needs Table/TableExtInfo/columns/data_path plumbing. The goal here is to stop the silent failure and make the limitation visible while Pages/Page work as the agent expects.