### PR TITLE
mutate_form_model: pre-flight reject CHECK_BOX_FIELD (and friends) in…

### DIFF
--- a/bundles/com.codepilot1c.core.tests/src/com/codepilot1c/core/edt/metadata/FormFieldTypeValidatorTest.java
+++ b/bundles/com.codepilot1c.core.tests/src/com/codepilot1c/core/edt/metadata/FormFieldTypeValidatorTest.java
@@ -1,0 +1,91 @@
+package com.codepilot1c.core.edt.metadata;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+/**
+ * Tests for {@link FormFieldTypeValidator}.
+ *
+ * <p>Pins the deny-list of {@code field_type} values that the 1C platform
+ * rejects inside a Table parent (SU107).  This is a pre-flight check so
+ * the agent gets an actionable error before the BM transaction fires.</p>
+ */
+public class FormFieldTypeValidatorTest {
+
+    // --- isIncompatibleWithTableParent --------------------------------------
+
+    @Test
+    public void rejectsCheckBoxFieldInAllSeparatorVariants() {
+        assertTrue(FormFieldTypeValidator.isIncompatibleWithTableParent("CHECK_BOX_FIELD")); //$NON-NLS-1$
+        assertTrue(FormFieldTypeValidator.isIncompatibleWithTableParent("CheckBoxField")); //$NON-NLS-1$
+        assertTrue(FormFieldTypeValidator.isIncompatibleWithTableParent("checkboxfield")); //$NON-NLS-1$
+        assertTrue(FormFieldTypeValidator.isIncompatibleWithTableParent("check-box-field")); //$NON-NLS-1$
+        assertTrue(FormFieldTypeValidator.isIncompatibleWithTableParent("CHECK BOX FIELD")); //$NON-NLS-1$
+        assertTrue(FormFieldTypeValidator.isIncompatibleWithTableParent(" check_box_field ")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void rejectsOtherTableIncompatibleTypes() {
+        assertTrue(FormFieldTypeValidator.isIncompatibleWithTableParent("RADIO_BUTTON_FIELD")); //$NON-NLS-1$
+        assertTrue(FormFieldTypeValidator.isIncompatibleWithTableParent("RadioButtonField")); //$NON-NLS-1$
+        assertTrue(FormFieldTypeValidator.isIncompatibleWithTableParent("PROGRESS_BAR_FIELD")); //$NON-NLS-1$
+        assertTrue(FormFieldTypeValidator.isIncompatibleWithTableParent("TRACK_BAR_FIELD")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void acceptsTypesValidInsideTables() {
+        // The platform accepts these inside a Table — agent must not be tripped up.
+        assertFalse(FormFieldTypeValidator.isIncompatibleWithTableParent("INPUT_FIELD")); //$NON-NLS-1$
+        assertFalse(FormFieldTypeValidator.isIncompatibleWithTableParent("LABEL_FIELD")); //$NON-NLS-1$
+        assertFalse(FormFieldTypeValidator.isIncompatibleWithTableParent("PICTURE_FIELD")); //$NON-NLS-1$
+        assertFalse(FormFieldTypeValidator.isIncompatibleWithTableParent("BUTTON_FIELD")); //$NON-NLS-1$
+        // Lowercase variants of valid types should also pass.
+        assertFalse(FormFieldTypeValidator.isIncompatibleWithTableParent("input_field")); //$NON-NLS-1$
+        assertFalse(FormFieldTypeValidator.isIncompatibleWithTableParent("InputField")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void handlesNullAndEmpty() {
+        assertFalse(FormFieldTypeValidator.isIncompatibleWithTableParent(null));
+        assertFalse(FormFieldTypeValidator.isIncompatibleWithTableParent("")); //$NON-NLS-1$
+        assertFalse(FormFieldTypeValidator.isIncompatibleWithTableParent("   ")); //$NON-NLS-1$
+    }
+
+    // --- tableIncompatibleFieldTypeMessage ----------------------------------
+
+    @Test
+    public void messageEchoesRawFieldTypeAndPointsToInputField() {
+        String msg = FormFieldTypeValidator.tableIncompatibleFieldTypeMessage("CHECK_BOX_FIELD", "PricingTablePayment"); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("must echo raw field_type:\n" + msg, msg.contains("CHECK_BOX_FIELD")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("must mention SU107:\n" + msg, msg.contains("SU107")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("must point to INPUT_FIELD:\n" + msg, msg.contains("INPUT_FIELD")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("must mention Table parent:\n" + msg, msg.contains("Table")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("must echo field name when present:\n" + msg, //$NON-NLS-1$
+                msg.contains("PricingTablePayment")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void messageOmitsFieldNameWhenBlank() {
+        String msg = FormFieldTypeValidator.tableIncompatibleFieldTypeMessage("CHECK_BOX_FIELD", null); //$NON-NLS-1$
+        assertFalse("must not include 'field name=' when field name is null:\n" + msg, //$NON-NLS-1$
+                msg.contains("field name=")); //$NON-NLS-1$
+        msg = FormFieldTypeValidator.tableIncompatibleFieldTypeMessage("CHECK_BOX_FIELD", "  "); //$NON-NLS-1$ //$NON-NLS-2$
+        assertFalse("must not include 'field name=' when field name is blank:\n" + msg, //$NON-NLS-1$
+                msg.contains("field name=")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void messageRoundTripIsStableForSnapshotsOfCommonCase() {
+        // Pin the exact wording so a refactor cannot drift the agent-facing
+        // language without an explicit test update.
+        String msg = FormFieldTypeValidator.tableIncompatibleFieldTypeMessage("CHECK_BOX_FIELD", "Active"); //$NON-NLS-1$ //$NON-NLS-2$
+        assertEquals("field_type 'CHECK_BOX_FIELD' is not allowed inside a Table parent (field name='Active'):" //$NON-NLS-1$
+                + " the 1C platform rejects it with SU107 'Illegal extension type for field type'." //$NON-NLS-1$
+                + " Use field_type=\"INPUT_FIELD\" — Boolean cells render as a checkmark automatically," //$NON-NLS-1$
+                + " choice cells render as a dropdown, and so on.", //$NON-NLS-1$
+                msg);
+    }
+}

--- a/bundles/com.codepilot1c.core/src/com/codepilot1c/core/edt/metadata/EdtMetadataService.java
+++ b/bundles/com.codepilot1c.core/src/com/codepilot1c/core/edt/metadata/EdtMetadataService.java
@@ -840,6 +840,7 @@ public class EdtMetadataService {
                                 MetadataOperationCode.INVALID_METADATA_NAME,
                                 "Invalid field name: " + name, false); //$NON-NLS-1$
                     }
+                    rejectTableIncompatibleFieldType(parentContainer, operation, name);
                     Map<String, Object> set = extractAddFieldSet(operation);
                     Integer index = asOptionalInteger(operation.get("index"), "index"); //$NON-NLS-1$ //$NON-NLS-2$
                     FormField field = addFieldItem(
@@ -2324,6 +2325,48 @@ public class EdtMetadataService {
                         MetadataOperationCode.INVALID_METADATA_CHANGE,
                         "Use {\"op\":\"add_group\"} instead of {\"op\":\"add\",\"type\":\"group\"}", false); //$NON-NLS-1$
             }
+        }
+    }
+
+    /**
+     * Pre-flight check: certain {@code field_type} values (CHECK_BOX_FIELD,
+     * RADIO_BUTTON_FIELD, PROGRESS_BAR_FIELD, TRACK_BAR_FIELD) are flagged by the
+     * 1C platform with diagnostic SU107 ("Illegal extension type for field type")
+     * when they appear inside a Table.  Boolean cells render via
+     * {@code INPUT_FIELD} automatically, so converting/replacing those is what the
+     * agent ultimately wants.  Surface a clear message before the BM transaction
+     * fires.
+     */
+    private void rejectTableIncompatibleFieldType(
+            FormItemContainer parentContainer,
+            Map<String, Object> operation,
+            String fieldName
+    ) {
+        if (parentContainer == null || operation == null) {
+            return;
+        }
+        String parentClassName = parentContainer.eClass() != null
+                ? parentContainer.eClass().getName()
+                : null;
+        if (!"Table".equals(parentClassName)) { //$NON-NLS-1$
+            return;
+        }
+        String rawFieldType = asString(getMapValueIgnoreCase(operation, "field_type")); //$NON-NLS-1$
+        if (rawFieldType == null) {
+            rawFieldType = asString(getMapValueIgnoreCase(operation, "fieldType")); //$NON-NLS-1$
+        }
+        if (rawFieldType == null) {
+            Map<String, Object> set = asMap(operation.get("set")); //$NON-NLS-1$
+            rawFieldType = asString(getMapValueIgnoreCase(set, "field_type")); //$NON-NLS-1$
+            if (rawFieldType == null) {
+                rawFieldType = asString(getMapValueIgnoreCase(set, "fieldType")); //$NON-NLS-1$
+            }
+        }
+        if (FormFieldTypeValidator.isIncompatibleWithTableParent(rawFieldType)) {
+            throw new MetadataOperationException(
+                    MetadataOperationCode.INVALID_METADATA_CHANGE,
+                    FormFieldTypeValidator.tableIncompatibleFieldTypeMessage(rawFieldType, fieldName),
+                    false);
         }
     }
 

--- a/bundles/com.codepilot1c.core/src/com/codepilot1c/core/edt/metadata/FormFieldTypeValidator.java
+++ b/bundles/com.codepilot1c.core/src/com/codepilot1c/core/edt/metadata/FormFieldTypeValidator.java
@@ -1,0 +1,81 @@
+package com.codepilot1c.core.edt.metadata;
+
+import java.util.Locale;
+import java.util.Set;
+
+/**
+ * Pure-Java helpers for validating {@code field_type} values supplied to
+ * {@code mutate_form_model.add_field} before they reach the BM API.
+ *
+ * <p>Catches one common gotcha: the agent often sends
+ * {@code field_type:"CHECK_BOX_FIELD"} for Boolean cells inside a Table.
+ * The 1C platform rejects this with a cryptic {@code SU107} ("Illegal
+ * extension type for field type 'CheckBoxField'") because Table cells
+ * render Boolean automatically through {@code INPUT_FIELD}.</p>
+ *
+ * <p>Surfacing the constraint here gives the agent an actionable error
+ * <em>before</em> the BM transaction runs.  No behavioural change for
+ * field types outside the deny-list — those continue to round-trip into
+ * the platform unchanged.</p>
+ */
+public final class FormFieldTypeValidator {
+
+    /**
+     * Field types that the 1C platform refuses inside a Table.  Boolean
+     * columns are rendered via {@code INPUT_FIELD} (the platform draws
+     * a checkmark for Boolean data automatically); the dedicated
+     * {@code CHECK_BOX_FIELD}, {@code RADIO_BUTTON_FIELD},
+     * {@code PROGRESS_BAR_FIELD} and {@code TRACK_BAR_FIELD} extension
+     * types are flagged by SU107 when used inside a Table.
+     */
+    private static final Set<String> TABLE_INCOMPATIBLE_FIELD_TYPES = Set.of(
+            "CHECKBOXFIELD", //$NON-NLS-1$
+            "RADIOBUTTONFIELD", //$NON-NLS-1$
+            "PROGRESSBARFIELD", //$NON-NLS-1$
+            "TRACKBARFIELD"); //$NON-NLS-1$
+
+    private FormFieldTypeValidator() {
+    }
+
+    /**
+     * Returns {@code true} if the given field-type string is incompatible
+     * with a Table parent (rejected by SU107 at platform level).
+     *
+     * @param fieldType raw {@code field_type} string from the agent payload
+     *                  (case-insensitive, {@code _}/{@code -}/space ignored;
+     *                  may be null/blank)
+     * @return {@code true} if the platform would reject this field type
+     *         inside a Table parent
+     */
+    public static boolean isIncompatibleWithTableParent(String fieldType) {
+        if (fieldType == null) {
+            return false;
+        }
+        String normalized = fieldType
+                .replace("_", "") //$NON-NLS-1$ //$NON-NLS-2$
+                .replace("-", "") //$NON-NLS-1$ //$NON-NLS-2$
+                .replace(" ", "") //$NON-NLS-1$ //$NON-NLS-2$
+                .toUpperCase(Locale.ROOT);
+        return TABLE_INCOMPATIBLE_FIELD_TYPES.contains(normalized);
+    }
+
+    /**
+     * Builds the canonical "use INPUT_FIELD instead" error message.
+     *
+     * @param rawFieldType the raw field-type string the caller supplied
+     *                     (echoed back verbatim)
+     * @param fieldName field name from the operation, may be null
+     * @return human-readable error message
+     */
+    public static String tableIncompatibleFieldTypeMessage(String rawFieldType, String fieldName) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("field_type '").append(rawFieldType).append("' is not allowed inside a Table parent"); //$NON-NLS-1$ //$NON-NLS-2$
+        if (fieldName != null && !fieldName.isBlank()) {
+            sb.append(" (field name='").append(fieldName).append("')"); //$NON-NLS-1$ //$NON-NLS-2$
+        }
+        sb.append(": the 1C platform rejects it with SU107 'Illegal extension type for field type'."); //$NON-NLS-1$
+        sb.append(" Use field_type=\"INPUT_FIELD\" — Boolean cells render as a checkmark automatically,"); //$NON-NLS-1$
+        sb.append(" choice cells render as a dropdown, and so on."); //$NON-NLS-1$
+        return sb.toString();
+    }
+}


### PR DESCRIPTION
…side a Table parent

Background
----------
add_field with field_type:"CHECK_BOX_FIELD" inside a Table parent was quietly forwarded into the BM API.  The 1C platform then rejected it with diagnostic SU107 ("Illegal extension type for field type 'CheckBoxField'") because Table cells render Boolean automatically via INPUT_FIELD — there is no separate CheckBoxField extension type for table cells.  RADIO_BUTTON_FIELD, PROGRESS_BAR_FIELD, and TRACK_BAR_FIELD behave the same way.

The agent had to hit SU107 first (often surfaced as a generic EDT_TRANSACTION_FAILED) and reverse-engineer the platform rule from the diagnostic text before retrying with INPUT_FIELD.


Fix
---
- Add FormFieldTypeValidator (pure-Java, OSGi-free) that owns the deny-list and the agent-facing error wording.  Normalization mirrors EdtMetadataService.normalizeToken: strip _ - <space>, upper-case.
- EdtMetadataService.applyFormModelOperations now calls rejectTableIncompatibleFieldType(parentContainer, operation, name) immediately after resolveTargetContainer.  When the parent's eClass name is "Table" and field_type is on the deny-list, fail fast with:

      "field_type '<rawFieldType>' is not allowed inside a Table parent
       (field name='<name>'): the 1C platform rejects it with SU107
       'Illegal extension type for field type'.  Use
       field_type=\"INPUT_FIELD\" — Boolean cells render as a
       checkmark automatically, choice cells render as a dropdown,
       and so on."

  Field types outside the deny-list (INPUT_FIELD, LABEL_FIELD, PICTURE_FIELD, BUTTON_FIELD) and non-Table parents are unchanged.

Tests
-----
FormFieldTypeValidatorTest pins:
- CHECK_BOX_FIELD recognized in every common separator/case variant (CHECK_BOX_FIELD, CheckBoxField, checkboxfield, check-box-field, "CHECK BOX FIELD", " check_box_field ")
- RADIO_BUTTON_FIELD / PROGRESS_BAR_FIELD / TRACK_BAR_FIELD also recognized
- INPUT_FIELD / LABEL_FIELD / PICTURE_FIELD / BUTTON_FIELD pass (negative test for the deny-list)
- null / empty / blank inputs do not flip recognition
- error message echoes the raw field_type, names SU107, points at INPUT_FIELD, mentions Table, and includes the field name only when non-blank
- exact wording snapshot for the common (CHECK_BOX_FIELD, "Active") case