### PR TITLE
metadata BM API: write synonyms under the project's default language …

### DIFF
--- a/bundles/com.codepilot1c.core.tests/src/com/codepilot1c/core/edt/metadata/BmSynonymLocaleResolverTest.java
+++ b/bundles/com.codepilot1c.core.tests/src/com/codepilot1c/core/edt/metadata/BmSynonymLocaleResolverTest.java
@@ -1,0 +1,63 @@
+package com.codepilot1c.core.edt.metadata;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Test;
+
+/**
+ * Tests for {@link BmSynonymLocaleResolver}.
+ *
+ * <p>The resolver is the pure-data backbone of the BF-8908 Gap 4 fix for
+ * locale handling: previously every newly-created synonym landed under
+ * key {@code "ru"} regardless of the project's actual default language.
+ * This test pins each step of the resolution chain so a refactor cannot
+ * silently revert to the historical hard-coded behaviour.</p>
+ */
+public class BmSynonymLocaleResolverTest {
+
+    @Test
+    public void preferenceOrder_explicitDefaultWins() {
+        assertEquals("en", BmSynonymLocaleResolver.resolve("en", List.of("ru", "en"))); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+        assertEquals("de", BmSynonymLocaleResolver.resolve("de", List.of("en", "ru"))); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+    }
+
+    @Test
+    public void preferenceOrder_firstNonBlankFromConfigurationWhenDefaultMissing() {
+        assertEquals("en", BmSynonymLocaleResolver.resolve(null, List.of("en", "ru"))); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+        assertEquals("ru", BmSynonymLocaleResolver.resolve("", List.of("ru"))); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+        assertEquals("uk", BmSynonymLocaleResolver.resolve("   ", List.of("uk", "en"))); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+    }
+
+    @Test
+    public void preferenceOrder_skipsBlankConfigurationEntries() {
+        assertEquals("en", BmSynonymLocaleResolver.resolve(null, Arrays.asList(null, "", "  ", "en", "ru"))); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$
+    }
+
+    @Test
+    public void preferenceOrder_fallbackWhenNothingUsable() {
+        assertEquals(BmSynonymLocaleResolver.FALLBACK_LANGUAGE_CODE,
+                BmSynonymLocaleResolver.resolve(null, List.of()));
+        assertEquals(BmSynonymLocaleResolver.FALLBACK_LANGUAGE_CODE,
+                BmSynonymLocaleResolver.resolve(null, null));
+        assertEquals(BmSynonymLocaleResolver.FALLBACK_LANGUAGE_CODE,
+                BmSynonymLocaleResolver.resolve("", Arrays.asList(null, "  "))); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void fallbackKeyMatchesHistoricalBehaviour() {
+        // Existing AM and other Russian-only fixtures must keep landing on "ru" so
+        // already-checked-in .mdo files stay valid after the resolver lands.
+        assertEquals("ru", BmSynonymLocaleResolver.FALLBACK_LANGUAGE_CODE); //$NON-NLS-1$
+    }
+
+    @Test
+    public void resolveTrimsWhitespaceFromAcceptedCode() {
+        // Configuration files occasionally carry trailing whitespace in the
+        // languageCode; we must not write "ru " or " en" into the synonym map.
+        assertEquals("en", BmSynonymLocaleResolver.resolve(" en ", List.of("ru"))); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+        assertEquals("uk", BmSynonymLocaleResolver.resolve(null, List.of(" uk ", "en"))); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+    }
+}

--- a/bundles/com.codepilot1c.core/src/com/codepilot1c/core/edt/metadata/BmSynonymLocaleResolver.java
+++ b/bundles/com.codepilot1c.core/src/com/codepilot1c/core/edt/metadata/BmSynonymLocaleResolver.java
@@ -1,0 +1,69 @@
+package com.codepilot1c.core.edt.metadata;
+
+import java.util.List;
+
+/**
+ * Resolves the language-code key under which to write a synonym value when
+ * creating or updating BM-API metadata objects.
+ *
+ * <p>Historically {@code setCommonProperties} hard-coded {@code "ru"} for
+ * the synonym map.  English-only configurations (and any project whose
+ * default language is not Russian) therefore had to be patched after every
+ * BM-API call to flip {@code <key>ru</key>} to {@code <key>en</key>}.
+ * The resolver consults the Configuration's default-language and full
+ * language list so a freshly-created object lands with the correct locale
+ * the first time.</p>
+ *
+ * <p>The pure-data {@link #resolve(String, List)} entry point keeps the
+ * logic unit-testable without an Eclipse OSGi runtime.</p>
+ */
+public final class BmSynonymLocaleResolver {
+
+    /**
+     * Fallback used when no Configuration language is available.  Matches
+     * the historical behaviour so existing fixtures continue to work for
+     * Russian-only projects.
+     */
+    public static final String FALLBACK_LANGUAGE_CODE = "ru"; //$NON-NLS-1$
+
+    private BmSynonymLocaleResolver() {
+    }
+
+    /**
+     * Pick the synonym key from raw inputs.
+     *
+     * <p>Resolution order:</p>
+     * <ol>
+     *   <li>{@code defaultLanguageCode} if non-blank;</li>
+     *   <li>first non-blank entry of {@code configurationLanguageCodes};</li>
+     *   <li>{@link #FALLBACK_LANGUAGE_CODE} ({@code "ru"}).</li>
+     * </ol>
+     *
+     * <p>This deterministic chain matches what an EDT user sees in the
+     * Configuration editor: the platform itself uses the default-language
+     * for new synonyms, and a project that has only one configured language
+     * effectively makes that language the default even when no explicit
+     * default is set.</p>
+     *
+     * @param defaultLanguageCode {@code Configuration.defaultLanguage.languageCode}, may be null/blank
+     * @param configurationLanguageCodes ordered codes from {@code Configuration.languages}, may be empty
+     * @return non-null, non-blank language code
+     */
+    public static String resolve(String defaultLanguageCode, List<String> configurationLanguageCodes) {
+        if (isUsable(defaultLanguageCode)) {
+            return defaultLanguageCode.trim();
+        }
+        if (configurationLanguageCodes != null) {
+            for (String code : configurationLanguageCodes) {
+                if (isUsable(code)) {
+                    return code.trim();
+                }
+            }
+        }
+        return FALLBACK_LANGUAGE_CODE;
+    }
+
+    private static boolean isUsable(String code) {
+        return code != null && !code.isBlank();
+    }
+}

--- a/bundles/com.codepilot1c.core/src/com/codepilot1c/core/edt/metadata/EdtMetadataService.java
+++ b/bundles/com.codepilot1c.core/src/com/codepilot1c/core/edt/metadata/EdtMetadataService.java
@@ -262,7 +262,7 @@ public class EdtMetadataService {
 
             MdObject object = createTopLevelObject(request.kind());
             LOG.debug("[%s] Created object instance: %s", opId, object.eClass().getName()); //$NON-NLS-1$
-            setCommonProperties(object, request.name(), request.synonym(), request.comment());
+            setCommonProperties(object, request.name(), request.synonym(), request.comment(), txConfiguration);
             MdObject txObject = attachTopLevelObject(transaction, project, object, fqn);
             LOG.debug("[%s] Attached top object by FQN=%s", opId, fqn); //$NON-NLS-1$
             ensureUuidsRecursively(txObject, opId, fqn);
@@ -347,7 +347,7 @@ public class EdtMetadataService {
             }
             validateReservedChildName(owner, MetadataChildKind.FORM, capturedName);
             MdObject form = createFormByParent(owner);
-            setCommonProperties(form, capturedName, request.synonym(), request.comment());
+            setCommonProperties(form, capturedName, request.synonym(), request.comment(), txConfiguration);
             initializeFormForRequest(form, request);
             ensureUuidsRecursively(form, opId, formFqn);
             try {
@@ -4196,7 +4196,7 @@ public class EdtMetadataService {
                     ? createFormByParent(parent)
                     : createChildByFactory(parent, effectiveKind);
             LOG.debug("createGenericChild created child class=%s", child.eClass().getName()); //$NON-NLS-1$
-            setCommonProperties(child, request.name(), request.synonym(), request.comment());
+            setCommonProperties(child, request.name(), request.synonym(), request.comment(), configuration);
             initializeFormIfNeeded(child);
             initializeTemplateIfNeeded(child, request.properties());
             ensureUuidsRecursively(child, "child", request.parentFqn()); //$NON-NLS-1$
@@ -5184,7 +5184,7 @@ public class EdtMetadataService {
             }
             validateReservedChildName(parent, kind, name);
             MdObject child = createChildByFactory(parent, kind);
-            setCommonProperties(child, name, asString(rawMap.get("synonym")), asString(rawMap.get("comment"))); //$NON-NLS-1$ //$NON-NLS-2$
+            setCommonProperties(child, name, asString(rawMap.get("synonym")), asString(rawMap.get("comment")), configuration); //$NON-NLS-1$ //$NON-NLS-2$
             @SuppressWarnings("unchecked")
             Map<String, Object> childProperties = (Map<String, Object>) rawMap;
             initializeTemplateIfNeeded(child, childProperties);
@@ -8514,14 +8514,41 @@ public class EdtMetadataService {
     }
 
     private void setCommonProperties(MdObject object, String name, String synonym, String comment) {
+        // Backwards-compatible entry point: callers that do not have a
+        // Configuration in scope (e.g. external-project flows or recursive
+        // form initialization) keep landing on the historical "ru" key.
+        setCommonProperties(object, name, synonym, comment, (Configuration) null);
+    }
+
+    private void setCommonProperties(
+            MdObject object,
+            String name,
+            String synonym,
+            String comment,
+            Configuration configuration
+    ) {
+        setCommonProperties(object, name, synonym, comment, resolveSynonymLocaleKey(configuration));
+    }
+
+    private void setCommonProperties(
+            MdObject object,
+            String name,
+            String synonym,
+            String comment,
+            String synonymLocaleKey
+    ) {
         if (object.getUuid() == null) {
             object.setUuid(UUID.randomUUID());
         }
-        LOG.debug("setCommonProperties class=%s name=%s synonym=%s commentLength=%s", // $NON-NLS-1$
+        String effectiveKey = synonymLocaleKey == null || synonymLocaleKey.isBlank()
+                ? BmSynonymLocaleResolver.FALLBACK_LANGUAGE_CODE
+                : synonymLocaleKey;
+        LOG.debug("setCommonProperties class=%s name=%s synonym=%s commentLength=%s synonymKey=%s", // $NON-NLS-1$
                 object.eClass().getName(),
                 name,
                 synonym != null ? LogSanitizer.truncate(synonym, 80) : "null", //$NON-NLS-1$
-                comment != null ? comment.length() : 0);
+                comment != null ? comment.length() : 0,
+                effectiveKey);
         object.setName(name);
         if (comment != null && !comment.isBlank()) {
             object.setComment(comment);
@@ -8529,9 +8556,41 @@ public class EdtMetadataService {
         if (synonym != null && !synonym.isBlank()) {
             EMap<String, String> synonymMap = object.getSynonym();
             if (synonymMap != null) {
-                synonymMap.put(RU_LANGUAGE, synonym);
+                synonymMap.put(effectiveKey, synonym);
             }
         }
+    }
+
+    /**
+     * Resolves the synonym-map key for a Configuration: prefers
+     * {@code defaultLanguage.languageCode}, falls back to the first
+     * configured language, and finally to {@code "ru"} for parity with
+     * the historical hard-coded behaviour.
+     */
+    private String resolveSynonymLocaleKey(Configuration configuration) {
+        if (configuration == null) {
+            return BmSynonymLocaleResolver.FALLBACK_LANGUAGE_CODE;
+        }
+        String defaultCode = null;
+        try {
+            com._1c.g5.v8.dt.metadata.mdclass.Language defaultLanguage = configuration.getDefaultLanguage();
+            if (defaultLanguage != null) {
+                defaultCode = defaultLanguage.getLanguageCode();
+            }
+        } catch (Exception e) {
+            LOG.debug("resolveSynonymLocaleKey: defaultLanguage unavailable: %s", e.getMessage()); //$NON-NLS-1$
+        }
+        List<String> codes = new ArrayList<>();
+        try {
+            for (com._1c.g5.v8.dt.metadata.mdclass.Language language : configuration.getLanguages()) {
+                if (language != null) {
+                    codes.add(language.getLanguageCode());
+                }
+            }
+        } catch (Exception e) {
+            LOG.debug("resolveSynonymLocaleKey: languages list unavailable: %s", e.getMessage()); //$NON-NLS-1$
+        }
+        return BmSynonymLocaleResolver.resolve(defaultCode, codes);
     }
 
     private void repairConfigurationMissingUuids(IProject project, String opId) {


### PR DESCRIPTION
…code, not always "ru"

Background
----------
EdtMetadataService.setCommonProperties hard-coded the synonym-map key to "ru".  Every newly-created top-level object, child attribute, tabular section, form, etc. landed with:

  <synonym>
    <key>ru</key>
    <value>...</value>
  </synonym>

…even on configurations whose default and only language is English (as in the AM project).  Agents had to follow each create_metadata / add_metadata_child / create_form call with a manual .mdo patch that flipped "ru" -> "en".  For BF-8908 this happened on every one of 23 attributes, 3 tabular sections, 1 catalog and 3 enums.


Fix
---
- Add BmSynonymLocaleResolver, a pure-Java helper with resolve(String defaultLanguageCode, List<String> configurationLanguageCodes).
  Resolution chain: explicit default -> first configured language ->
  "ru" fallback (preserves historical behaviour for Russian-only fixtures and projects with no configured Languages).
- EdtMetadataService now resolves the synonym key from the live Configuration via: Configuration.getDefaultLanguage().getLanguageCode() Configuration.getLanguages().*.getLanguageCode() Three setCommonProperties overloads cooperate: the historical 3-argument signature stays as a no-op-on-locale fallback for callers that do not have a Configuration in scope; new overloads accept a Configuration or an explicit synonymLocaleKey.
- Wire the Configuration through to:
    * createMetadata top-level object
    * addMetadataChild single-child path
    * addMetadataChild batch (children) path
    * createForm path These are the four BM-API entry points that produce the synonym payload the agent sees.

Tests
-----
BmSynonymLocaleResolverTest pins:
- explicit default language wins over the configured-list head
- when default is null/blank, the first non-blank configured language wins; null/blank list entries are skipped
- "ru" fallback is used when nothing is usable, AND the constant is pinned to "ru" so already-checked-in fixtures keep validating
- whitespace-padded codes (" en ") are trimmed before being written into the synonym map