### PR TITLE
update_metadata: reject children_ops add/create with a clear pointer …

### DIFF
--- a/bundles/com.codepilot1c.core.tests/src/com/codepilot1c/core/edt/metadata/ChildrenOpsValidatorTest.java
+++ b/bundles/com.codepilot1c.core.tests/src/com/codepilot1c/core/edt/metadata/ChildrenOpsValidatorTest.java
@@ -1,0 +1,84 @@
+package com.codepilot1c.core.edt.metadata;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+/**
+ * Tests for {@link ChildrenOpsValidator}.
+ *
+ * <p>Pins the rejection list for {@code update_metadata.children_ops} ops
+ * that express "create a new child" intent.  The previous behaviour leaked
+ * an indirect "child_fqn is required" / "Metadata child object not found"
+ * error sequence that made the agent think the request was malformed,
+ * when the real diagnosis is "wrong tool — use add_metadata_child".</p>
+ */
+public class ChildrenOpsValidatorTest {
+
+    @Test
+    public void normalizeOpTokenStripsUnderscoresHyphensAndSpaces() {
+        assertEquals("addchild", ChildrenOpsValidator.normalizeOpToken("add_child")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertEquals("addchild", ChildrenOpsValidator.normalizeOpToken("add-child")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertEquals("addchild", ChildrenOpsValidator.normalizeOpToken("add child")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertEquals("createchild", ChildrenOpsValidator.normalizeOpToken("Create_Child")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertEquals("", ChildrenOpsValidator.normalizeOpToken(null)); //$NON-NLS-1$
+        assertEquals("", ChildrenOpsValidator.normalizeOpToken("")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void recognizesAddIntentAcrossCommonAliases() {
+        // The exact tokens the BF-8908 handoff used and the most plausible alternates.
+        assertTrue(ChildrenOpsValidator.isCreateChildIntent("add")); //$NON-NLS-1$
+        assertTrue(ChildrenOpsValidator.isCreateChildIntent("addchild")); //$NON-NLS-1$
+        assertTrue(ChildrenOpsValidator.isCreateChildIntent("create")); //$NON-NLS-1$
+        assertTrue(ChildrenOpsValidator.isCreateChildIntent("createchild")); //$NON-NLS-1$
+        assertTrue(ChildrenOpsValidator.isCreateChildIntent("new")); //$NON-NLS-1$
+        assertTrue(ChildrenOpsValidator.isCreateChildIntent("newchild")); //$NON-NLS-1$
+        assertTrue(ChildrenOpsValidator.isCreateChildIntent("insert")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void recognizesAddIntentThroughNormalizationPipeline() {
+        // Caller code does normalizeOpToken(...) first.  Verify the round trip.
+        assertTrue(ChildrenOpsValidator.isCreateChildIntent(
+                ChildrenOpsValidator.normalizeOpToken("add"))); //$NON-NLS-1$
+        assertTrue(ChildrenOpsValidator.isCreateChildIntent(
+                ChildrenOpsValidator.normalizeOpToken("Add_Child"))); //$NON-NLS-1$
+        assertTrue(ChildrenOpsValidator.isCreateChildIntent(
+                ChildrenOpsValidator.normalizeOpToken("CREATE-CHILD"))); //$NON-NLS-1$
+        assertTrue(ChildrenOpsValidator.isCreateChildIntent(
+                ChildrenOpsValidator.normalizeOpToken(" insert "))); //$NON-NLS-1$
+    }
+
+    @Test
+    public void doesNotMisfireOnSupportedOps() {
+        // These are the ops EdtMetadataService.applyChildOperations actually handles.
+        assertFalse(ChildrenOpsValidator.isCreateChildIntent("rename")); //$NON-NLS-1$
+        assertFalse(ChildrenOpsValidator.isCreateChildIntent("renamechild")); //$NON-NLS-1$
+        assertFalse(ChildrenOpsValidator.isCreateChildIntent("delete")); //$NON-NLS-1$
+        assertFalse(ChildrenOpsValidator.isCreateChildIntent("deletechild")); //$NON-NLS-1$
+        assertFalse(ChildrenOpsValidator.isCreateChildIntent("remove")); //$NON-NLS-1$
+        assertFalse(ChildrenOpsValidator.isCreateChildIntent("set")); //$NON-NLS-1$
+        assertFalse(ChildrenOpsValidator.isCreateChildIntent("setchildprops")); //$NON-NLS-1$
+        assertFalse(ChildrenOpsValidator.isCreateChildIntent("update")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void doesNotMisfireOnNullOrEmpty() {
+        assertFalse(ChildrenOpsValidator.isCreateChildIntent(null));
+        assertFalse(ChildrenOpsValidator.isCreateChildIntent("")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void rejectionMessageEchoesRawOpAndPointsToCorrectTool() {
+        String message = ChildrenOpsValidator.createChildIntentRejectionMessage("Add"); //$NON-NLS-1$
+        assertTrue("rejection message must echo the raw op verbatim:\n" + message, //$NON-NLS-1$
+                message.contains("'Add'")); //$NON-NLS-1$
+        assertTrue("rejection message must point at add_metadata_child:\n" + message, //$NON-NLS-1$
+                message.contains("add_metadata_child")); //$NON-NLS-1$
+        assertTrue("rejection message must mention the parent_fqn/child_kind shape:\n" + message, //$NON-NLS-1$
+                message.contains("parent_fqn") && message.contains("child_kind")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+}

--- a/bundles/com.codepilot1c.core/src/com/codepilot1c/core/edt/metadata/ChildrenOpsValidator.java
+++ b/bundles/com.codepilot1c.core/src/com/codepilot1c/core/edt/metadata/ChildrenOpsValidator.java
@@ -1,0 +1,80 @@
+package com.codepilot1c.core.edt.metadata;
+
+import java.util.Locale;
+import java.util.Set;
+
+/**
+ * Pure-Java validation helpers for {@code update_metadata.children_ops}.
+ *
+ * <p>Extracted from {@link EdtMetadataService} so the upstream-facing rules
+ * can be unit-tested without an Eclipse OSGi runtime.</p>
+ */
+public final class ChildrenOpsValidator {
+
+    /**
+     * Op-aliases that callers commonly send when they want to <em>create</em>
+     * a new child object.  {@code children_ops} only operates on already-
+     * existing children, so we reject these explicitly and route the agent
+     * to {@code add_metadata_child}.
+     *
+     * <p>Keys here are the post-{@link #normalizeOpToken(String)} form
+     * ({@code "_"}, {@code "-"}, {@code " "} stripped, lower-cased).</p>
+     */
+    private static final Set<String> CREATE_INTENT_OPS = Set.of(
+            "add", //$NON-NLS-1$
+            "addchild", //$NON-NLS-1$
+            "create", //$NON-NLS-1$
+            "createchild", //$NON-NLS-1$
+            "new", //$NON-NLS-1$
+            "newchild", //$NON-NLS-1$
+            "insert"); //$NON-NLS-1$
+
+    private ChildrenOpsValidator() {
+    }
+
+    /**
+     * Normalizes an {@code op} string the same way {@link EdtMetadataService}
+     * does internally: strip {@code _ - <space>}, lower-case (root locale).
+     *
+     * @param value raw op string from the JSON payload (may be null)
+     * @return normalized token, never null
+     */
+    public static String normalizeOpToken(String value) {
+        if (value == null) {
+            return ""; //$NON-NLS-1$
+        }
+        return value
+                .replace("_", "") //$NON-NLS-1$ //$NON-NLS-2$
+                .replace("-", "") //$NON-NLS-1$ //$NON-NLS-2$
+                .replace(" ", "") //$NON-NLS-1$ //$NON-NLS-2$
+                .toLowerCase(Locale.ROOT);
+    }
+
+    /**
+     * Returns {@code true} if {@code normalizedOp} expresses the intent to
+     * create a brand-new child object.  Callers should reject these with a
+     * pointer to the {@code add_metadata_child} tool — {@code children_ops}
+     * cannot create objects.
+     *
+     * @param normalizedOp output of {@link #normalizeOpToken(String)}
+     * @return {@code true} if the op represents a create-child intent
+     */
+    public static boolean isCreateChildIntent(String normalizedOp) {
+        return normalizedOp != null && CREATE_INTENT_OPS.contains(normalizedOp);
+    }
+
+    /**
+     * Builds the canonical "use add_metadata_child instead" error message.
+     * Keeping the wording in one place makes it easier to assert on in
+     * tests and to keep agent-facing language consistent.
+     *
+     * @param rawOp the original op string the caller supplied (echoed back)
+     * @return human-readable error message
+     */
+    public static String createChildIntentRejectionMessage(String rawOp) {
+        return "children_ops op '" + rawOp //$NON-NLS-1$
+                + "' is not supported: children_ops only operates on existing children." //$NON-NLS-1$
+                + " To create a new child use the add_metadata_child tool" //$NON-NLS-1$
+                + " (parent_fqn=<target>, child_kind=<Attribute|TabularSection|EnumValue|...>)."; //$NON-NLS-1$
+    }
+}

--- a/bundles/com.codepilot1c.core/src/com/codepilot1c/core/edt/metadata/EdtMetadataService.java
+++ b/bundles/com.codepilot1c.core/src/com/codepilot1c/core/edt/metadata/EdtMetadataService.java
@@ -5674,6 +5674,18 @@ public class EdtMetadataService {
                         MetadataOperationCode.INVALID_METADATA_CHANGE,
                         "children_ops item must contain op", false); //$NON-NLS-1$
             }
+            String normalizedOp = normalizeToken(opType);
+            // children_ops only operates on already-existing children. The agent must use
+            // add_metadata_child for creation — surface that explicitly so the agent doesn't
+            // hit the indirect "child_fqn is required" / "Metadata child object not found"
+            // sequence and conclude the request is malformed.  Logic lives in a pure helper
+            // so it can be unit-tested without an Eclipse OSGi runtime.
+            if (ChildrenOpsValidator.isCreateChildIntent(normalizedOp)) {
+                throw new MetadataOperationException(
+                        MetadataOperationCode.INVALID_METADATA_CHANGE,
+                        ChildrenOpsValidator.createChildIntentRejectionMessage(opType),
+                        false);
+            }
             String childFqn = asString(op.get("child_fqn")); //$NON-NLS-1$
             if (childFqn == null || childFqn.isBlank()) {
                 throw new MetadataOperationException(
@@ -5693,7 +5705,7 @@ public class EdtMetadataService {
                         "Metadata child object not found: " + childFqn, false); //$NON-NLS-1$
             }
 
-            String normalizedOp = normalizeToken(opType);
+
             switch (normalizedOp) {
                 case "renamechild", "rename" -> renameChildObject(child, childFqn, asString(op.get("new_name"))); //$NON-NLS-1$ //$NON-NLS-2$
                 case "deletechild", "delete", "remove" -> { //$NON-NLS-1$ //$NON-NLS-2$

--- a/bundles/com.codepilot1c.core/src/com/codepilot1c/core/tools/metadata/UpdateMetadataTool.java
+++ b/bundles/com.codepilot1c.core/src/com/codepilot1c/core/tools/metadata/UpdateMetadataTool.java
@@ -40,7 +40,7 @@ public class UpdateMetadataTool extends AbstractTool {
                 },
                 "changes": {
                   "type": "object",
-                  "description": "Property changes for an existing object: {set:{...}, unset:[...], children_ops:[...]}. Use add_metadata_child for a new child and mutate_form_model for forms."
+                  "description": "Property changes for an existing object: {set:{...}, unset:[...], children_ops:[...]}. children_ops only supports rename/delete/set on EXISTING children (op: rename|delete|set). To CREATE a new child use add_metadata_child; to mutate form layout use mutate_form_model."
                 },
                 "validation_token": {
                   "type": "string",


### PR DESCRIPTION
…to add_metadata_child

Background
----------
update_metadata.children_ops only operates on already-existing children: the supported ops are rename / delete / set.  When the agent sent op:"add" (or "create" / "new" / "insert") to populate, e.g., a freshly- created Enum, the request walked an indirect failure path:

  1. apply: "[INVALID_METADATA_CHANGE] children_ops item must contain child_fqn"
  2. agent supplies child_fqn pointing at the future child
  3. apply: "[METADATA_NOT_FOUND] Metadata child object not found: <fqn>"

The agent then concluded the request was malformed rather than that it was using the wrong tool.  add_metadata_child is the correct tool for creation; this commit makes the failure mode explicit.


Fix
---
- Extract a small ChildrenOpsValidator utility (pure Java, no Eclipse runtime) that owns the create-intent op-name list and the rejection message wording.  Keeping the strings in one place makes the agent- facing language consistent and unit-testable in isolation.
- EdtMetadataService.applyChildOperations now consults ChildrenOpsValidator.isCreateChildIntent BEFORE running the child_fqn-required check, so add/create/new/insert (with their _-, -, space variants) fail fast with:

      "children_ops op '<rawOp>' is not supported: children_ops only
       operates on existing children. To create a new child use the
       add_metadata_child tool (parent_fqn=<target>,
       child_kind=<Attribute|TabularSection|EnumValue|...>)."

- UpdateMetadataTool.SCHEMA changes-field description now spells out the supported ops (rename|delete|set) and points at add_metadata_child for creation.

Tests
-----
ChildrenOpsValidatorTest pins:
- normalizeOpToken strips _ - <space> and lower-cases
- create-intent recognized for: add, addchild, create, createchild, new, newchild, insert
- create-intent recognized through the normalization pipeline ("Add_Child", "CREATE-CHILD", " insert " all rejected)
- supported ops (rename, delete, set, update, setchildprops, ...) are NOT rejected
- null and empty op are NOT rejected (the existing "children_ops item must contain op" guard handles those)
- rejection message echoes the raw op and names the correct tool