### PR TITLE
edt_diagnostics: advertise per-command required fields and alias proj…

### DIFF
--- a/bundles/com.codepilot1c.core.tests/src/com/codepilot1c/core/tools/diagnostics/EdtDiagnosticsCommandContractTest.java
+++ b/bundles/com.codepilot1c.core.tests/src/com/codepilot1c/core/tools/diagnostics/EdtDiagnosticsCommandContractTest.java
@@ -1,0 +1,177 @@
+package com.codepilot1c.core.tools.diagnostics;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Test;
+
+/**
+ * Tests for {@link EdtDiagnosticsCommandContract}.
+ *
+ * <p>Pins the per-command required-field contract for {@code edt_diagnostics}
+ * and the {@code project}/{@code project_name} alias behaviour, so a refactor
+ * cannot silently regress the BF-8908 minor fix.</p>
+ */
+public class EdtDiagnosticsCommandContractTest {
+
+    // --- requiredFields -----------------------------------------------------
+
+    @Test
+    public void requiredFields_metadataSmokeNeedsProject() {
+        assertEquals(List.of("project"), //$NON-NLS-1$
+                EdtDiagnosticsCommandContract.requiredFields("metadata_smoke")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void requiredFields_traceExportNeedsProject() {
+        assertEquals(List.of("project"), //$NON-NLS-1$
+                EdtDiagnosticsCommandContract.requiredFields("trace_export")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void requiredFields_analyzeErrorNeedsToolResult() {
+        assertEquals(List.of("tool_result"), //$NON-NLS-1$
+                EdtDiagnosticsCommandContract.requiredFields("analyze_error")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void requiredFields_updateInfobaseAndLaunchAppNeedProjectName() {
+        assertEquals(List.of("project_name"), //$NON-NLS-1$
+                EdtDiagnosticsCommandContract.requiredFields("update_infobase")); //$NON-NLS-1$
+        assertEquals(List.of("project_name"), //$NON-NLS-1$
+                EdtDiagnosticsCommandContract.requiredFields("launch_app")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void requiredFields_unknownCommandReturnsEmpty() {
+        assertTrue(EdtDiagnosticsCommandContract.requiredFields("does_not_exist").isEmpty()); //$NON-NLS-1$
+        assertTrue(EdtDiagnosticsCommandContract.requiredFields(null).isEmpty());
+    }
+
+    // --- findFirstMissingRequired ------------------------------------------
+
+    @Test
+    public void findFirstMissing_returnsFieldNameWhenMissing() {
+        assertEquals("project", //$NON-NLS-1$
+                EdtDiagnosticsCommandContract.findFirstMissingRequired(
+                        "metadata_smoke", //$NON-NLS-1$
+                        Map.of("command", "metadata_smoke"))); //$NON-NLS-1$ //$NON-NLS-2$
+        assertEquals("tool_result", //$NON-NLS-1$
+                EdtDiagnosticsCommandContract.findFirstMissingRequired(
+                        "analyze_error", //$NON-NLS-1$
+                        Map.of("command", "analyze_error"))); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void findFirstMissing_returnsNullWhenAllRequiredPresent() {
+        assertNull(EdtDiagnosticsCommandContract.findFirstMissingRequired(
+                "metadata_smoke", //$NON-NLS-1$
+                Map.of("command", "metadata_smoke", "project", "AM"))); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+        assertNull(EdtDiagnosticsCommandContract.findFirstMissingRequired(
+                "update_infobase", //$NON-NLS-1$
+                Map.of("command", "update_infobase", "project_name", "AM"))); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+    }
+
+    @Test
+    public void findFirstMissing_blankStringIsTreatedAsMissing() {
+        assertEquals("project", //$NON-NLS-1$
+                EdtDiagnosticsCommandContract.findFirstMissingRequired(
+                        "metadata_smoke", //$NON-NLS-1$
+                        Map.of("command", "metadata_smoke", "project", "  "))); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+    }
+
+    @Test
+    public void findFirstMissing_unknownCommandReturnsNull() {
+        // Unknown commands are handled by the parent dispatcher; the contract
+        // helper does not block them.
+        assertNull(EdtDiagnosticsCommandContract.findFirstMissingRequired(
+                "fictional", Map.of())); //$NON-NLS-1$
+        assertNull(EdtDiagnosticsCommandContract.findFirstMissingRequired(null, Map.of()));
+    }
+
+    // --- missingRequiredFieldMessage ---------------------------------------
+
+    @Test
+    public void missingMessage_namesCommandFieldAndAlias() {
+        String msg = EdtDiagnosticsCommandContract.missingRequiredFieldMessage(
+                "metadata_smoke", "project"); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("must echo command:\n" + msg, msg.contains("metadata_smoke")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("must echo missing field:\n" + msg, msg.contains("'project'")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("must mention project_name alias:\n" + msg, msg.contains("project_name")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("must show example payload:\n" + msg, //$NON-NLS-1$
+                msg.contains("\"command\":\"metadata_smoke\"") //$NON-NLS-1$
+                && msg.contains("\"project\"")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void missingMessage_doesNotShowAliasForToolResult() {
+        // tool_result has no alias; message must not invent one.
+        String msg = EdtDiagnosticsCommandContract.missingRequiredFieldMessage(
+                "analyze_error", "tool_result"); //$NON-NLS-1$ //$NON-NLS-2$
+        assertFalse("tool_result has no alias:\n" + msg, msg.contains("alias")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    // --- applyProjectFieldAliases ------------------------------------------
+
+    @Test
+    public void aliases_projectMirroredToProjectName() {
+        Map<String, Object> in = Map.of("command", "update_infobase", "project", "AM"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+        Map<String, Object> out = EdtDiagnosticsCommandContract.applyProjectFieldAliases(in);
+        assertEquals("AM", out.get("project")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertEquals("AM", out.get("project_name")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void aliases_projectNameMirroredToProject() {
+        Map<String, Object> in = Map.of("command", "metadata_smoke", "project_name", "AM"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+        Map<String, Object> out = EdtDiagnosticsCommandContract.applyProjectFieldAliases(in);
+        assertEquals("AM", out.get("project")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertEquals("AM", out.get("project_name")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void aliases_existingValueWins() {
+        // If both fields are supplied with different values, neither should be overwritten.
+        Map<String, Object> in = new LinkedHashMap<>();
+        in.put("project", "AM"); //$NON-NLS-1$ //$NON-NLS-2$
+        in.put("project_name", "Different"); //$NON-NLS-1$ //$NON-NLS-2$
+
+        Map<String, Object> out = EdtDiagnosticsCommandContract.applyProjectFieldAliases(in);
+        assertEquals("AM", out.get("project")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertEquals("Different", out.get("project_name")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void aliases_nullAndEmptyInputsHandledGracefully() {
+        assertNull(EdtDiagnosticsCommandContract.applyProjectFieldAliases(null));
+        assertTrue(EdtDiagnosticsCommandContract.applyProjectFieldAliases(Map.of()).isEmpty());
+    }
+
+    @Test
+    public void aliases_doNotMutateInput() {
+        Map<String, Object> in = new LinkedHashMap<>();
+        in.put("command", "update_infobase"); //$NON-NLS-1$ //$NON-NLS-2$
+        in.put("project", "AM"); //$NON-NLS-1$ //$NON-NLS-2$
+        EdtDiagnosticsCommandContract.applyProjectFieldAliases(in);
+        // Original map should not have gained project_name.
+        assertFalse(in.containsKey("project_name")); //$NON-NLS-1$
+    }
+
+    // --- describeRequirements ----------------------------------------------
+
+    @Test
+    public void describeRequirements_listsAllFiveCommands() {
+        String desc = EdtDiagnosticsCommandContract.describeRequirements();
+        assertTrue(desc.contains("metadata_smoke -> project")); //$NON-NLS-1$
+        assertTrue(desc.contains("trace_export -> project")); //$NON-NLS-1$
+        assertTrue(desc.contains("analyze_error -> tool_result")); //$NON-NLS-1$
+        assertTrue(desc.contains("update_infobase -> project_name")); //$NON-NLS-1$
+        assertTrue(desc.contains("launch_app -> project_name")); //$NON-NLS-1$
+    }
+}

--- a/bundles/com.codepilot1c.core/src/com/codepilot1c/core/tools/diagnostics/EdtDiagnosticsCommandContract.java
+++ b/bundles/com.codepilot1c.core/src/com/codepilot1c/core/tools/diagnostics/EdtDiagnosticsCommandContract.java
@@ -1,0 +1,152 @@
+package com.codepilot1c.core.tools.diagnostics;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Pure-Java contract describing what each {@code edt_diagnostics}
+ * sub-command requires from its caller.
+ *
+ * <p>The composite tool advertised {@code command} as the only required
+ * field of its JSON schema, but every delegate had its own per-command
+ * required fields ({@code project}, {@code project_name},
+ * {@code tool_result}).  Agents discovered the constraint only after the
+ * call failed inside the delegate with
+ * {@code [INVALID_ARGUMENT] project is required} — a confusing error
+ * because the parent schema never mentioned the field.</p>
+ *
+ * <p>This helper centralizes the contract so the parent tool can:</p>
+ * <ul>
+ *   <li>fail fast with a clear "command X requires field Y" message,</li>
+ *   <li>render the per-command requirements in the tool description,</li>
+ *   <li>alias {@code project} → {@code project_name} for the workspace
+ *       delegates so callers don't need to remember which name applies.</li>
+ * </ul>
+ */
+public final class EdtDiagnosticsCommandContract {
+
+    /**
+     * Field-naming alias map: workspace delegates historically use
+     * {@code project_name}, while metadata delegates use the shorter
+     * {@code project}.  When a caller supplies one, populate the other.
+     */
+    private static final Map<String, String> PROJECT_FIELD_ALIASES = Map.of(
+            "project", "project_name", //$NON-NLS-1$ //$NON-NLS-2$
+            "project_name", "project"); //$NON-NLS-1$ //$NON-NLS-2$
+
+    /** Per-command required fields. Order is significant for the message. */
+    private static final Map<String, List<String>> REQUIRED_FIELDS_BY_COMMAND;
+    static {
+        Map<String, List<String>> table = new LinkedHashMap<>();
+        table.put("metadata_smoke", List.of("project")); //$NON-NLS-1$ //$NON-NLS-2$
+        table.put("trace_export", List.of("project")); //$NON-NLS-1$ //$NON-NLS-2$
+        table.put("analyze_error", List.of("tool_result")); //$NON-NLS-1$ //$NON-NLS-2$
+        table.put("update_infobase", List.of("project_name")); //$NON-NLS-1$ //$NON-NLS-2$
+        table.put("launch_app", List.of("project_name")); //$NON-NLS-1$ //$NON-NLS-2$
+        REQUIRED_FIELDS_BY_COMMAND = Map.copyOf(table);
+    }
+
+    private EdtDiagnosticsCommandContract() {
+    }
+
+    /**
+     * Required fields for {@code command} (empty if the command is unknown).
+     */
+    public static List<String> requiredFields(String command) {
+        if (command == null) {
+            return List.of();
+        }
+        return REQUIRED_FIELDS_BY_COMMAND.getOrDefault(command, List.of());
+    }
+
+    /**
+     * Find the first required-field that is missing from {@code params}.
+     * A field is considered present if its value is non-null and (for
+     * strings) non-blank.
+     *
+     * @param command sub-command name; if unknown, no fields are checked
+     * @param params caller-supplied parameter map
+     * @return missing field name, or {@code null} if all required fields
+     *         are present
+     */
+    public static String findFirstMissingRequired(String command, Map<String, Object> params) {
+        if (command == null) {
+            return null;
+        }
+        Map<String, Object> view = params == null ? Map.of() : params;
+        for (String required : requiredFields(command)) {
+            if (!isPresent(view, required)) {
+                return required;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Build the agent-facing error message for a missing required field.
+     * Mentions the alias so the caller knows both spellings work.
+     */
+    public static String missingRequiredFieldMessage(String command, String missingField) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("edt_diagnostics command '").append(command).append("' requires '") //$NON-NLS-1$ //$NON-NLS-2$
+                .append(missingField).append("'"); //$NON-NLS-1$
+        String alias = PROJECT_FIELD_ALIASES.get(missingField);
+        if (alias != null) {
+            sb.append(" (or alias '").append(alias).append("')"); //$NON-NLS-1$ //$NON-NLS-2$
+        }
+        sb.append(" — supplied parameters did not include it. Pass {\"command\":\"") //$NON-NLS-1$
+                .append(command).append("\", \"").append(missingField).append("\":\"...\"}."); //$NON-NLS-1$ //$NON-NLS-2$
+        return sb.toString();
+    }
+
+    /**
+     * Mirror caller-supplied {@code project}/{@code project_name} into the
+     * partner key so each delegate sees the field-name it expects.
+     * Returns a NEW map; the input is not mutated.
+     */
+    public static Map<String, Object> applyProjectFieldAliases(Map<String, Object> params) {
+        if (params == null || params.isEmpty()) {
+            return params;
+        }
+        Map<String, Object> aliased = new LinkedHashMap<>(params);
+        for (Map.Entry<String, String> alias : PROJECT_FIELD_ALIASES.entrySet()) {
+            String source = alias.getKey();
+            String target = alias.getValue();
+            if (isPresent(aliased, source) && !isPresent(aliased, target)) {
+                aliased.put(target, aliased.get(source));
+            }
+        }
+        return aliased;
+    }
+
+    /**
+     * Pretty-print the contract as a one-line-per-command list, suitable
+     * for embedding in the tool description.
+     */
+    public static String describeRequirements() {
+        StringBuilder sb = new StringBuilder();
+        boolean first = true;
+        for (Map.Entry<String, List<String>> entry : REQUIRED_FIELDS_BY_COMMAND.entrySet()) {
+            if (!first) {
+                sb.append("; "); //$NON-NLS-1$
+            }
+            first = false;
+            sb.append(entry.getKey()).append(" -> "); //$NON-NLS-1$
+            sb.append(String.join(",", entry.getValue())); //$NON-NLS-1$
+        }
+        return sb.toString();
+    }
+
+    private static boolean isPresent(Map<String, Object> map, String key) {
+        Object value = map.get(key);
+        if (value == null) {
+            return false;
+        }
+        if (value instanceof String s) {
+            return !s.isBlank();
+        }
+        return !Objects.toString(value, "").isBlank(); //$NON-NLS-1$
+    }
+}

--- a/bundles/com.codepilot1c.core/src/com/codepilot1c/core/tools/diagnostics/EdtDiagnosticsTool.java
+++ b/bundles/com.codepilot1c.core/src/com/codepilot1c/core/tools/diagnostics/EdtDiagnosticsTool.java
@@ -45,6 +45,18 @@ public class EdtDiagnosticsTool extends AbstractTool {
                   "type": "string",
                   "description": "Diagnostics command. Use metadata_smoke for headless verification, trace_export for export issues, analyze_error for a concrete error payload, update_infobase or launch_app for runtime workflow.",
                   "enum": ["metadata_smoke", "trace_export", "analyze_error", "update_infobase", "launch_app"]
+                },
+                "project": {
+                  "type": "string",
+                  "description": "EDT project name. REQUIRED for command=metadata_smoke or trace_export. Also accepted as an alias for project_name in update_infobase / launch_app."
+                },
+                "project_name": {
+                  "type": "string",
+                  "description": "EDT project name. REQUIRED for command=update_infobase or launch_app. Also accepted as an alias for project in metadata_smoke / trace_export."
+                },
+                "tool_result": {
+                  "type": "object",
+                  "description": "Structured tool result/error payload. REQUIRED for command=analyze_error."
                 }
               },
               "required": ["command"],
@@ -77,7 +89,10 @@ public class EdtDiagnosticsTool extends AbstractTool {
 
     @Override
     public String getDescription() {
-        return "Запускает EDT диагностику и runtime-команды: smoke, trace export, разбор ошибок, обновление инфобазы и запуск приложения."; //$NON-NLS-1$
+        return "Запускает EDT диагностику и runtime-команды: smoke, trace export, разбор ошибок, обновление инфобазы и запуск приложения. " //$NON-NLS-1$
+                + "Per-command required fields: " //$NON-NLS-1$
+                + EdtDiagnosticsCommandContract.describeRequirements()
+                + ". project and project_name are interchangeable aliases."; //$NON-NLS-1$
     }
 
     @Override
@@ -105,6 +120,20 @@ public class EdtDiagnosticsTool extends AbstractTool {
                             ". Use one of: " + String.join(", ", ALL_COMMANDS))); //$NON-NLS-1$ //$NON-NLS-2$
         }
 
+        // Apply project/project_name aliasing so each delegate sees the field-name it
+        // expects, regardless of which one the caller supplied.
+        Map<String, Object> aliased = EdtDiagnosticsCommandContract.applyProjectFieldAliases(p);
+
+        // Pre-flight per-command required-field check.  This used to fail inside
+        // the delegate with a confusing "[INVALID_ARGUMENT] project is required"
+        // because the parent schema never advertised the field; now we surface it
+        // up-front with a message that names the right field for the chosen command.
+        String missing = EdtDiagnosticsCommandContract.findFirstMissingRequired(command, aliased);
+        if (missing != null) {
+            return CompletableFuture.completedFuture(
+                    ToolResult.failure(EdtDiagnosticsCommandContract.missingRequiredFieldMessage(command, missing)));
+        }
+
         ITool delegate = switch (command) {
             case "metadata_smoke" -> metadataSmoke; //$NON-NLS-1$
             case "trace_export" -> traceExport; //$NON-NLS-1$
@@ -119,7 +148,7 @@ public class EdtDiagnosticsTool extends AbstractTool {
                     ToolResult.failure("Unknown command: " + command)); //$NON-NLS-1$
         }
 
-        // Forward all parameters except "command" to the delegate tool
-        return delegate.execute(p);
+        // Forward parameters (with project alias applied) to the delegate tool
+        return delegate.execute(aliased);
     }
 }


### PR DESCRIPTION
…ect/project_name

Background
----------
edt_diagnostics is a composite tool that dispatches to five delegate tools (metadata_smoke, trace_export, analyze_error, update_infobase, launch_app).  Each delegate has its own per-command required field, but the parent SCHEMA only listed "command" as required.  The agent discovered the constraint only after the call failed inside the delegate with confusing errors:

  [INVALID_ARGUMENT] project is required          # metadata_smoke / trace_export
  [INVALID_ARGUMENT] project_name is required     # update_infobase / launch_app
  [INVALID_ARGUMENT] tool_result is required      # analyze_error

…and the JSON-schema MCP descriptor never advertised those fields, so there was no recovery path other than guessing.  The mismatch between "project" and "project_name" between the metadata-flavoured delegates and the workspace-flavoured delegates added another stumbling block.

Fix
---
- Add EdtDiagnosticsCommandContract — a pure-Java helper with:
    * requiredFields(command)            : per-command required-field list
    * findFirstMissingRequired(...)      : pre-flight check
    * missingRequiredFieldMessage(...)   : agent-facing error wording
    * applyProjectFieldAliases(params)   : mirror project <-> project_name
    * describeRequirements()             : one-line summary for the
                                           tool description

- EdtDiagnosticsTool now:
    * Advertises "project", "project_name" and "tool_result" in the JSON schema with descriptions explaining which command requires which.
    * In doExecute, applies the project/project_name alias map FIRST so each delegate sees the field-name it expects.  A caller can pass either name to any sub-command without remembering which the delegate uses.
    * Runs the per-command required-field check against the aliased map and fails fast with: "edt_diagnostics command 'metadata_smoke' requires 'project' (or alias 'project_name') — supplied parameters did not include it. Pass {\"command\":\"metadata_smoke\", \"project\":\"...\"}."
    * Embeds the per-command requirement summary into getDescription() so the LLM sees it on tool surface inspection.

Tests
-----
EdtDiagnosticsCommandContractTest pins:
- per-command required-field map (metadata_smoke/trace_export -> project, analyze_error -> tool_result, update_infobase/launch_app -> project_name)
- unknown command returns empty list and findFirstMissing returns null
- findFirstMissing detects missing fields and returns null when present; blank strings are treated as missing
- error message echoes command, missing field, and the alias when one exists; tool_result message correctly omits the alias hint
- alias map mirrors project<->project_name without overwriting existing values; null/empty inputs handled; original map not mutated
- describeRequirements lists all five commands