### PR TITLE
fix: NPE в EdtMetadataService при установке типа Число у BasicFeature

### DIFF
--- a/bundles/com.codepilot1c.core/src/com/codepilot1c/core/edt/metadata/EdtMetadataService.java
+++ b/bundles/com.codepilot1c.core/src/com/codepilot1c/core/edt/metadata/EdtMetadataService.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.ByteArrayInputStream;
 import java.lang.reflect.Method;
+import java.math.BigDecimal;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.charset.StandardCharsets;
@@ -92,6 +93,7 @@ import com._1c.g5.v8.dt.mcore.McoreFactory;
 import com._1c.g5.v8.dt.mcore.McorePackage;
 import com._1c.g5.v8.dt.mcore.NamedElement;
 import com._1c.g5.v8.dt.mcore.NumberQualifiers;
+import com._1c.g5.v8.dt.mcore.NumberValue;
 import com._1c.g5.v8.dt.mcore.StringQualifiers;
 import com._1c.g5.v8.dt.mcore.TypeDescription;
 import com._1c.g5.v8.dt.mcore.TypeItem;
@@ -5998,6 +6000,28 @@ public class EdtMetadataService {
         }
 
         feature.setType(typeDesc);
+        fixNullNumberFillValue(feature, typeName);
+    }
+
+    /**
+     * Fix NPE in ValueWriter.writeValue(): some EDT EMF adapters react to setType()
+     * by creating a NumberValue with null BigDecimal as FillValue.
+     * If found, replace with BigDecimal.ZERO so XML serialization succeeds.
+     */
+    private void fixNullNumberFillValue(BasicFeature feature, String typeName) {
+        if (!isNumberType(typeName)) {
+            return;
+        }
+        EStructuralFeature fillValueFeature = feature.eClass().getEStructuralFeature("fillValue"); //$NON-NLS-1$
+        if (fillValueFeature == null) {
+            return;
+        }
+        Object current = feature.eGet(fillValueFeature);
+        if (current instanceof NumberValue nv && nv.getValue() == null) {
+            nv.setValue(BigDecimal.ZERO);
+            LOG.debug("fixNullNumberFillValue: fixed null BigDecimal in FillValue for %s", //$NON-NLS-1$
+                    feature.eClass().getName());
+        }
     }
 
     private TypeItem resolveExternalTypeItemCandidate(


### PR DESCRIPTION
## Что

Фикс NPE при выставлении типа `Число` через MCP `update_metadata` для атрибута / измерения / реквизита.

## Симптомы

Когда через `update_metadata` ставится `type: { types: ["Number"] }`, EDT EMF-адаптер на `setType()` создаёт `NumberValue` с null `BigDecimal` как `FillValue`. Дальше при сохранении `.mdo` падает `ValueWriter.writeValue()` → `NullPointerException` (BigDecimal.toString от null).

## Что делает фикс

После `setType()` проверяю `FillValue`. Если это `NumberValue` с null `BigDecimal` — ставлю `BigDecimal.ZERO`. Сериализация проходит, поведение из коробки совпадает с EDT GUI (там тоже 0 по умолчанию).

## Файлы

1 файл, +24 строки: `EdtMetadataService.fixNullNumberFillValue()` + `import java.math.BigDecimal`, `import com._1c.g5.v8.dt.mcore.NumberValue`.

## Тестирование

Ловил вручную при попытке через MCP создать реквизит справочника с типом Число. После фикса — `update_metadata` отрабатывает чисто, `.mdo` пишется корректно.

Unit-тестов пока нет — фикс реактивный (на adapter'ах EDT), репродукция требует живой EDT-сессии.