### PR TITLE
fix: get_diagnostics(scope=file) больше не возвращает диагностики из чужих модулей

### DIFF
--- a/bundles/com.codepilot1c.ui/src/com/codepilot1c/ui/tools/GetDiagnosticsTool.java
+++ b/bundles/com.codepilot1c.ui/src/com/codepilot1c/ui/tools/GetDiagnosticsTool.java
@@ -98,7 +98,9 @@ public class GetDiagnosticsTool implements ITool {
         String severityStr = (String) parameters.getOrDefault("severity", "info"); //$NON-NLS-1$ //$NON-NLS-2$
         int maxItems = getIntParam(parameters, "max_items", 0); //$NON-NLS-1$
         long waitMs = getIntParam(parameters, "wait_ms", 0); //$NON-NLS-1$
-        boolean includeRuntimeMarkers = getBooleanParam(parameters, "include_runtime_markers", true); //$NON-NLS-1$
+        // For scope=file/active_editor, runtime markers default to false to avoid cross-module noise (issue #24)
+        boolean includeRuntimeMarkersDefault = !"file".equals(scope) && !"active_editor".equals(scope); //$NON-NLS-1$ //$NON-NLS-2$
+        boolean includeRuntimeMarkers = getBooleanParam(parameters, "include_runtime_markers", includeRuntimeMarkersDefault); //$NON-NLS-1$
 
         // Validate parameters
         if (maxItems < 0) maxItems = 0;


### PR DESCRIPTION
Closes #24

## Что

При `get_diagnostics(scope=file)` и `scope=active_editor` параметр `include_runtime_markers` теперь по умолчанию `false`.

## Зачем

Раньше runtime-маркеры из соседних модулей подмешивались в ответ, потому что они матчились по общим именам токенов, а не по точному пути файла. На запрос диагностики по одному модулю прилетали ошибки `undefined-variable` из совсем других модулей проекта.

## Поведение

- `scope=file` / `scope=active_editor` → `include_runtime_markers=false` по умолчанию (можно явно включить через аргумент)
- `scope=project` / `scope=all` / `scope=module` → поведение не меняется

Это `minimal approach` из исходного issue paveldudko (`disable runtime markers by default for scope=file`).

## Файлы

1 файл, +3/-1 строка: `GetDiagnosticsTool.java` — дефолт меняется в одном месте, проверка scope.

## Тестирование

Проверял вручную: при работе с конкретным модулем `get_diagnostics(scope=file)` теперь возвращает только маркеры этого файла. Для проектного сканирования по-прежнему `scope=project` / `all`.