### PR TITLE
FuzzyMatcher: stop duplicating root closing tag on .mdo edits

### DIFF
--- a/bundles/com.codepilot1c.core.tests/src/com/codepilot1c/core/edit/FuzzyMatcherWhitespaceTest.java
+++ b/bundles/com.codepilot1c.core.tests/src/com/codepilot1c/core/edit/FuzzyMatcherWhitespaceTest.java
@@ -31,7 +31,7 @@ public class FuzzyMatcherWhitespaceTest {
         MatchResult result = new FuzzyMatcher().findMatch(search, doc);
 
         assertTrue("match must succeed via whitespace normalization", result.isSuccess()); //$NON-NLS-1$
-        MatchLocation location = result.getLocation();
+        MatchLocation location = result.getLocation().orElseThrow();
         assertNotNull(location);
         assertEquals("matched text should be exactly the closing tag", //$NON-NLS-1$
                 "</root>", location.getMatchedText()); //$NON-NLS-1$
@@ -49,7 +49,7 @@ public class FuzzyMatcherWhitespaceTest {
         MatchResult result = new FuzzyMatcher().findMatch(search, doc);
 
         assertTrue(result.isSuccess());
-        MatchLocation location = result.getLocation();
+        MatchLocation location = result.getLocation().orElseThrow();
         assertEquals("matched text should cover both lines, preserving CRLF", //$NON-NLS-1$
                 "  <a/>\r\n</root>", location.getMatchedText()); //$NON-NLS-1$
         assertEquals(doc.length(), location.getEndOffset());
@@ -64,7 +64,7 @@ public class FuzzyMatcherWhitespaceTest {
         MatchResult result = new FuzzyMatcher().findMatch(search, doc);
 
         assertTrue(result.isSuccess());
-        MatchLocation location = result.getLocation();
+        MatchLocation location = result.getLocation().orElseThrow();
         assertEquals("beta   \ngamma", location.getMatchedText()); //$NON-NLS-1$
         assertEquals(doc.length(), location.getEndOffset());
     }
@@ -81,7 +81,7 @@ public class FuzzyMatcherWhitespaceTest {
 
         MatchResult result = new FuzzyMatcher().findMatch(search, doc);
         assertTrue(result.isSuccess());
-        MatchLocation location = result.getLocation();
+        MatchLocation location = result.getLocation().orElseThrow();
 
         String updated = doc.substring(0, location.getStartOffset())
                 + replacement

--- a/bundles/com.codepilot1c.core.tests/src/com/codepilot1c/core/edit/FuzzyMatcherWhitespaceTest.java
+++ b/bundles/com.codepilot1c.core.tests/src/com/codepilot1c/core/edit/FuzzyMatcherWhitespaceTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2024 Example
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package com.codepilot1c.core.edit;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+/**
+ * Tests for {@link FuzzyMatcher#findMatch} with the
+ * {@link MatchStrategy#NORMALIZE_WHITESPACE} fallback.
+ *
+ * <p>Pinned regression: a search text anchored at EOF in a CRLF document used
+ * to produce an off-by-one start (the {@code \n} half of a {@code \r\n} pair
+ * was double-counted) and a too-short end (only the orphaned {@code \n} was
+ * captured). Applying the resulting match left the original closing tag in
+ * place while the replacement added a new one, producing the famous
+ * {@code </root></root>} duplication seen on {@code .mdo} edits.
+ */
+public class FuzzyMatcherWhitespaceTest {
+
+    @Test
+    public void crlfDocumentEofAnchoredSearchCapturesFullClosingTag() {
+        String doc = "<root>\r\n  <a/>\r\n</root>"; //$NON-NLS-1$
+        String search = "</root>"; //$NON-NLS-1$
+
+        MatchResult result = new FuzzyMatcher().findMatch(search, doc);
+
+        assertTrue("match must succeed via whitespace normalization", result.isSuccess()); //$NON-NLS-1$
+        MatchLocation location = result.getLocation();
+        assertNotNull(location);
+        assertEquals("matched text should be exactly the closing tag", //$NON-NLS-1$
+                "</root>", location.getMatchedText()); //$NON-NLS-1$
+        assertEquals("end offset must reach EOF", doc.length(), location.getEndOffset()); //$NON-NLS-1$
+        assertEquals("start offset must point at '<' of '</root>'", //$NON-NLS-1$
+                doc.lastIndexOf("</root>"), location.getStartOffset()); //$NON-NLS-1$
+    }
+
+    @Test
+    public void crlfDocumentMultiLineSearchTouchingEofMatchesCleanly() {
+        String doc = "<root>\r\n  <a/>\r\n</root>"; //$NON-NLS-1$
+        // Search text uses LF (typical when LLM-generated) and ends at the closing tag with no trailing newline.
+        String search = "  <a/>\n</root>"; //$NON-NLS-1$
+
+        MatchResult result = new FuzzyMatcher().findMatch(search, doc);
+
+        assertTrue(result.isSuccess());
+        MatchLocation location = result.getLocation();
+        assertEquals("matched text should cover both lines, preserving CRLF", //$NON-NLS-1$
+                "  <a/>\r\n</root>", location.getMatchedText()); //$NON-NLS-1$
+        assertEquals(doc.length(), location.getEndOffset());
+    }
+
+    @Test
+    public void lfDocumentTrailingWhitespaceTolerated() {
+        // Document line has trailing spaces; search does not.
+        String doc = "alpha\nbeta   \ngamma"; //$NON-NLS-1$
+        String search = "beta\ngamma"; //$NON-NLS-1$
+
+        MatchResult result = new FuzzyMatcher().findMatch(search, doc);
+
+        assertTrue(result.isSuccess());
+        MatchLocation location = result.getLocation();
+        assertEquals("beta   \ngamma", location.getMatchedText()); //$NON-NLS-1$
+        assertEquals(doc.length(), location.getEndOffset());
+    }
+
+    @Test
+    public void replacementAtEofDoesNotDuplicateClosingTag() {
+        // Simulates the .mdo edit reported in the 2026-05-17 retest:
+        // - document ends with </close> and no trailing newline
+        // - search text covers the tail through </close>
+        // - new content keeps </close> at the end
+        String doc = "<root>\r\n  <a/>\r\n</close>"; //$NON-NLS-1$
+        String search = "  <a/>\n</close>"; //$NON-NLS-1$
+        String replacement = "  <a/>\n  <b/>\n</close>"; //$NON-NLS-1$
+
+        MatchResult result = new FuzzyMatcher().findMatch(search, doc);
+        assertTrue(result.isSuccess());
+        MatchLocation location = result.getLocation();
+
+        String updated = doc.substring(0, location.getStartOffset())
+                + replacement
+                + doc.substring(location.getEndOffset());
+
+        assertEquals("file must end with exactly one closing tag, not two", //$NON-NLS-1$
+                1, countOccurrences(updated, "</close>")); //$NON-NLS-1$
+        assertTrue("file should end with </close>", updated.endsWith("</close>")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    private static int countOccurrences(String haystack, String needle) {
+        int count = 0;
+        int idx = 0;
+        while ((idx = haystack.indexOf(needle, idx)) >= 0) {
+            count++;
+            idx += needle.length();
+        }
+        return count;
+    }
+}

--- a/bundles/com.codepilot1c.core/src/com/codepilot1c/core/edit/FuzzyMatcher.java
+++ b/bundles/com.codepilot1c.core/src/com/codepilot1c/core/edit/FuzzyMatcher.java
@@ -129,28 +129,34 @@ public class FuzzyMatcher {
 
     /**
      * Match with whitespace normalization.
+     *
+     * <p>Uses a positional map built during normalization to translate normalized
+     * offsets back to the original document. Previously this was done with two
+     * approximate helpers (line counting + char walking) that miscounted CRLF
+     * pairs and EOF-anchored matches, producing matched regions that didn't
+     * cover the trailing closing tag — replacements then duplicated it.
      */
     private MatchResult tryWhitespaceNormalizedMatch(String searchText, String documentContent) {
-        String normalizedSearch = normalizeWhitespace(searchText);
-        String normalizedDoc = normalizeWhitespace(documentContent);
+        NormalizationMap docMap = buildNormalizationMap(documentContent);
+        NormalizationMap searchMap = buildNormalizationMap(searchText);
 
-        int normalizedIndex = normalizedDoc.indexOf(normalizedSearch);
+        int normalizedIndex = docMap.normalized.indexOf(searchMap.normalized);
         if (normalizedIndex < 0) {
             return MatchResult.failure("Совпадение не найдено после нормализации пробелов"); //$NON-NLS-1$
         }
 
-        // Map back to original offsets
-        int originalStart = mapNormalizedToOriginal(documentContent, normalizedDoc, normalizedIndex);
-        int originalEnd = findOriginalEnd(documentContent, originalStart, searchText, normalizedSearch.length());
+        int normalizedEnd = normalizedIndex + searchMap.normalized.length();
+        int originalStart = docMap.toOriginal(normalizedIndex);
+        int originalEnd = docMap.toOriginal(normalizedEnd);
 
         // Check uniqueness
-        int secondIndex = normalizedDoc.indexOf(normalizedSearch, normalizedIndex + 1);
+        int secondIndex = docMap.normalized.indexOf(searchMap.normalized, normalizedIndex + 1);
         if (secondIndex >= 0) {
             List<MatchResult.SimilarMatch> candidates = new ArrayList<>();
             candidates.add(extractCandidate(documentContent, originalStart, originalEnd));
-            int secondOriginalStart = mapNormalizedToOriginal(documentContent, normalizedDoc, secondIndex);
-            int secondOriginalEnd = findOriginalEnd(documentContent, secondOriginalStart, searchText, normalizedSearch.length());
-            candidates.add(extractCandidate(documentContent, secondOriginalStart, secondOriginalEnd));
+            int secondStart = docMap.toOriginal(secondIndex);
+            int secondEnd = docMap.toOriginal(secondIndex + searchMap.normalized.length());
+            candidates.add(extractCandidate(documentContent, secondStart, secondEnd));
             return MatchResult.ambiguous(candidates);
         }
 
@@ -364,51 +370,99 @@ public class FuzzyMatcher {
     }
 
     /**
-     * Maps normalized index back to original document offset.
+     * Builds a positional map between the original text and its normalized form.
+     *
+     * <p>For every position in the normalized string the map records the
+     * corresponding offset in the original. The map has one extra entry beyond
+     * the last character that points at the past-the-end offset of the original
+     * — this lets callers translate a half-open {@code [start, end)} range in
+     * normalized space back to the exact byte range in the original.</p>
+     *
+     * <p>The normalization rules mirror {@link #normalizeWhitespace}:</p>
+     * <ul>
+     *   <li>{@code \r\n} and bare {@code \r} collapse to {@code \n} (one
+     *       normalized char consumed by two/one original chars).</li>
+     *   <li>Trailing whitespace runs before a newline / EOF are stripped from
+     *       the normalized output (zero normalized chars consumed by N original
+     *       chars).</li>
+     * </ul>
+     *
+     * @param original the original text
+     * @return a normalization map; never {@code null}
      */
-    private int mapNormalizedToOriginal(String original, String normalized, int normalizedIndex) {
-        // Simple approximation - count characters, adjusting for removed spaces
-        int originalIndex = 0;
-        int normalizedPos = 0;
+    private NormalizationMap buildNormalizationMap(String original) {
+        int len = original.length();
+        StringBuilder sb = new StringBuilder(len);
+        int[] map = new int[len + 1];
 
-        String normalizedOriginal = normalizeWhitespace(original);
-        while (normalizedPos < normalizedIndex && originalIndex < original.length()) {
-            char origChar = original.charAt(originalIndex);
-            if (normalizedPos < normalizedOriginal.length()) {
-                char normChar = normalizedOriginal.charAt(normalizedPos);
-                if (origChar == normChar || (origChar == '\r' && normChar == '\n')) {
-                    normalizedPos++;
+        int i = 0;
+        while (i < len) {
+            char c = original.charAt(i);
+            if (c == '\r') {
+                map[sb.length()] = i;
+                sb.append('\n');
+                i++;
+                if (i < len && original.charAt(i) == '\n') {
+                    i++;
                 }
+            } else if (c == '\n') {
+                map[sb.length()] = i;
+                sb.append('\n');
+                i++;
+            } else if (c == ' ' || c == '\t') {
+                // A whitespace run is "trailing" iff it ends at \r/\n/EOF.
+                int j = i;
+                while (j < len) {
+                    char d = original.charAt(j);
+                    if (d != ' ' && d != '\t') {
+                        break;
+                    }
+                    j++;
+                }
+                boolean trailing = j == len
+                        || original.charAt(j) == '\n'
+                        || original.charAt(j) == '\r';
+                if (trailing) {
+                    i = j;
+                } else {
+                    map[sb.length()] = i;
+                    sb.append(c);
+                    i++;
+                }
+            } else {
+                map[sb.length()] = i;
+                sb.append(c);
+                i++;
             }
-            originalIndex++;
         }
-        return originalIndex;
+        map[sb.length()] = len;
+        int[] trimmed = java.util.Arrays.copyOf(map, sb.length() + 1);
+        return new NormalizationMap(sb.toString(), trimmed);
     }
 
     /**
-     * Finds the end offset in original document.
+     * Positional map between a text and its whitespace-normalized form.
      */
-    private int findOriginalEnd(String documentContent, int originalStart, String searchText, int normalizedLength) {
-        // Approximate by finding the search text lines in document
-        String[] searchLines = searchText.split("\n", -1); //$NON-NLS-1$
-        int lineCount = searchLines.length;
+    private static final class NormalizationMap {
 
-        int currentLine = 0;
-        int pos = originalStart;
-        while (pos < documentContent.length() && currentLine < lineCount) {
-            int nextNewline = documentContent.indexOf('\n', pos);
-            if (nextNewline < 0) {
-                pos = documentContent.length();
-                break;
-            }
-            currentLine++;
-            pos = nextNewline + 1;
+        final String normalized;
+        private final int[] normToOrig;
+
+        NormalizationMap(String normalized, int[] normToOrig) {
+            this.normalized = normalized;
+            this.normToOrig = normToOrig;
         }
-        // Adjust for last line if not followed by newline
-        if (currentLine < lineCount && pos < documentContent.length()) {
-            pos = documentContent.length();
+
+        /**
+         * Translates a half-open offset in normalized space to the original.
+         *
+         * @param normalizedOffset offset in {@link #normalized},
+         *                         {@code 0 <= normalizedOffset <= normalized.length()}
+         * @return the corresponding offset in the original text
+         */
+        int toOriginal(int normalizedOffset) {
+            return normToOrig[normalizedOffset];
         }
-        return Math.min(pos, documentContent.length());
     }
 
     /**


### PR DESCRIPTION
## Summary

`edit_file` users hit this on `.mdo` files with CRLF line endings: after a single call the file ended with two closing tags (`</mdclass:DataProcessor></mdclass:DataProcessor>`), corrupting the metadata. Reported in the 2026-05-17 EdtFormPlayground gap report (Gap 12) and re-verified in the 2026-05-17 retest as still broken.

Root cause: `FuzzyMatcher.tryWhitespaceNormalizedMatch` used two approximate helpers (`mapNormalizedToOriginal` + `findOriginalEnd`) to map the normalized match back to original offsets. `mapNormalizedToOriginal` had a CRLF off-by-one — when a `\r` in original was accepted as `\n` in normalized space, the following `\n` of the `\r\n` pair was not skipped, so origIdx returned one short. `findOriginalEnd` then found that orphaned `\n` and barely advanced, leaving the matched region containing just `\n` instead of the actual trailing tag. The replacement kept the original closing tag in place and added another → duplicate.

## What changed

- Replace both helpers with a positional `NormalizationMap` built during normalization. The map records, for every normalized offset, the corresponding offset in the original. Half-open `[start, end)` ranges translate directly. `\r\n`, bare `\r`, and trailing-whitespace runs are handled explicitly during construction so callers always get exact byte ranges back.
- Drop `mapNormalizedToOriginal` and `findOriginalEnd` (no remaining callers).
- Add `FuzzyMatcherWhitespaceTest` with four cases:
  - EOF-anchored single-line search in a CRLF document.
  - Multi-line search touching EOF; the matched text preserves CRLF.
  - Trailing-whitespace tolerance in an LF document.
  - End-to-end replacement scenario asserting only one closing tag remains.

## Test plan

- [ ] `mvn -B clean verify` (the new test follows JUnit 4 conventions used elsewhere in `com.codepilot1c.core.tests`; couldn't run locally this session — Tycho target-platform setup for Windows ran into a separate issue, see below)
- [ ] Smoke `edit_file` on a CRLF `.mdo` with a search anchored at the closing root tag — confirm one closing tag after the edit

## Notes for the maintainer

Local `mvn verify` on the Windows dev workstation needs the EDT path set — `targets/default/default.target` hardcodes a macOS path. I opted to keep this PR focused on the bug fix; a separate change to either parameterize the target file or add an opt-in `local-build` profile would unblock Windows contributors. Happy to send that as a follow-up if you'd like.

🤖 Generated with [Claude Code](https://claude.com/claude-code)