### PR TITLE
feat: поддержать ValueStorage / ХранилищеЗначения как простой тип

### DIFF
--- a/bundles/com.codepilot1c.core/src/com/codepilot1c/core/edt/metadata/EdtMetadataService.java
+++ b/bundles/com.codepilot1c.core/src/com/codepilot1c/core/edt/metadata/EdtMetadataService.java
@@ -6951,6 +6951,10 @@ public class EdtMetadataService {
                 queries.add("Boolean"); //$NON-NLS-1$
                 queries.add("Булево"); //$NON-NLS-1$
             }
+            case "valuestorage", "хранилищезначения" -> {
+                queries.add("ValueStorage"); //$NON-NLS-1$
+                queries.add("ХранилищеЗначения"); //$NON-NLS-1$
+            }
             default -> {
                 // no-op
             }
@@ -7556,6 +7560,7 @@ public class EdtMetadataService {
             case "number", "число" -> "Number"; //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
             case "date", "дата" -> "Date"; //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
             case "boolean", "bool", "булево" -> "Boolean"; //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+            case "valuestorage", "хранилищезначения" -> "ValueStorage"; //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
             default -> null;
         };
     }


### PR DESCRIPTION
## Симптом

`mcp__codepilot1c__add_metadata_child` с `properties.type="ValueStorage"` (или `"ХранилищеЗначения"`) падает:

```
[INVALID_PROPERTY_VALUE] Type not found in BM: ValueStorage
```

При этом 1С-платформа поддерживает `ValueStorage` как тип ресурса РегистраСведений / реквизита справочника и т.п. (стандартный примитивный тип для блобов, как `String`/`Number`/`Date`).

## Корневая причина

В `EdtMetadataService.java`:

1. `canonicalSimpleTypeName` (switch): отсутствуют case-ветки для `valuestorage`/`хранилищезначения` → `isSimpleTypeQuery` возвращает `false`.
2. `addSimpleTypeAliases` (switch): отсутствуют алиасы `ValueStorage`/`ХранилищеЗначения` → BM-поиск по этим именам не находит существующий платформенный `TypeItem`.
3. Gate в `preResolveChildTypes`: `if (item == null && !isSimpleTypeQuery(typeString))` → throw. ValueStorage проваливал оба условия.

## Фикс

5 строк (две case-ветки):

- `canonicalSimpleTypeName`: `case "valuestorage", "хранилищезначения" -> "ValueStorage";`
- `addSimpleTypeAliases`: добавлены алиасы `ValueStorage`/`ХранилищеЗначения` для BM-поиска.

После фикса BM находит существующий платформенный `TypeItem` для `ValueStorage`; safety-net через `isSimpleTypeQuery=true` остаётся на случай BM-miss.

## Использование

```
add_metadata_child child_kind=Resource name=МойРесурс
  properties={type: "ValueStorage"}     // или "ХранилищеЗначения" — case-insensitive
```

В .mdo пишется `<types>ValueStorage</types>` корректно.

В BSL: запись через `Новый ХранилищеЗначения(значение)`, чтение через `<поле>.Получить()`.

## Test plan

- [x] Собрано локально (`mvn -DskipTests -pl '!:com.codepilot1c.core.tests' package`) — BUILD SUCCESS.
- [x] Установлено в EDT, проверено: `add_metadata_child kind=Resource type=ValueStorage` создаёт ресурс, `.mdo` валиден, `update_infobase` грузит конфу без ошибок.
- [x] Проверено в реальном кейсе: `InformationRegister` с ресурсом-`ValueStorage` для хранения сериализованной 1С-структуры (`Новый ХранилищеЗначения(СтруктураОтвета)` / `<поле>.Получить()` — roundtrip чистый).
