### PR TITLE
fix(diagnostics): coerce update_infobase flags from JSON strings

### DIFF
--- a/bundles/com.codepilot1c.core.tests/src/com/codepilot1c/core/tools/EdtUpdateInfobaseToolTest.java
+++ b/bundles/com.codepilot1c.core.tests/src/com/codepilot1c/core/tools/EdtUpdateInfobaseToolTest.java
@@ -142,6 +142,40 @@ public class EdtUpdateInfobaseToolTest {
         assertTrue(resultJson.get("updated").getAsBoolean()); //$NON-NLS-1$
     }
 
+    @Test
+    public void async_stringTrue_returnsJobIdImmediately() throws Exception {
+        // Regression: "async":"true" (JSON string) must take the async path,
+        // not be silently coerced to false and block the MCP transport.
+        File workspaceRoot = Files.createTempDirectory("edt-update-tool-async-str").toFile(); //$NON-NLS-1$
+        CountDownLatch release = new CountDownLatch(1);
+        CountDownLatch entered = new CountDownLatch(1);
+        BlockingRuntimeService runtimeService = new BlockingRuntimeService(entered, release);
+        EdtUpdateInfobaseTool tool = new TestEdtUpdateInfobaseTool(
+                new StubProjectResolver(),
+                runtimeService,
+                workspaceRoot);
+
+        long t0 = System.currentTimeMillis();
+        ToolResult result = tool.execute(Map.of(
+                "project_name", "Demo", //$NON-NLS-1$ //$NON-NLS-2$
+                "async", "true" //$NON-NLS-1$ //$NON-NLS-2$
+        )).join();
+        long elapsed = System.currentTimeMillis() - t0;
+
+        assertTrue(result.isSuccess());
+        JsonObject json = JsonParser.parseString(result.getContent()).getAsJsonObject();
+        assertTrue(json.get("async").getAsBoolean()); //$NON-NLS-1$
+        assertEquals("RUNNING", json.get("state").getAsString()); //$NON-NLS-1$ //$NON-NLS-2$
+        String jobId = json.get("job_id").getAsString(); //$NON-NLS-1$
+        assertNotNull(jobId);
+        assertTrue("Async tool returned in " + elapsed + " ms", elapsed < 2000); //$NON-NLS-1$ //$NON-NLS-2$
+
+        // Drain the blocked background job so it doesn't leak into other tests.
+        release.countDown();
+        entered.await(5, TimeUnit.SECONDS);
+        pollForTerminal(BackgroundJobRegistry.getInstance(), jobId);
+    }
+
     private static JobStatus pollForTerminal(BackgroundJobRegistry registry, String jobId)
             throws InterruptedException {
         long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5);

--- a/bundles/com.codepilot1c.core/src/com/codepilot1c/core/tools/workspace/EdtUpdateInfobaseTool.java
+++ b/bundles/com.codepilot1c.core/src/com/codepilot1c/core/tools/workspace/EdtUpdateInfobaseTool.java
@@ -99,9 +99,11 @@ public class EdtUpdateInfobaseTool extends AbstractTool {
         String opId = LogSanitizer.newId("edt-update"); //$NON-NLS-1$
         File workspaceRoot = getWorkspaceRoot();
         String projectName = asString(parameters == null ? null : parameters.get("project_name")); //$NON-NLS-1$
-        boolean keepConnected = parameters == null || !Boolean.FALSE.equals(parameters.get("keep_connected")); //$NON-NLS-1$
-        boolean dryRun = parameters != null && Boolean.TRUE.equals(parameters.get("dry_run")); //$NON-NLS-1$
-        boolean async = parameters != null && Boolean.TRUE.equals(parameters.get("async")); //$NON-NLS-1$
+        // Lenient: callers reaching this tool through edt_diagnostics may ship
+        // these as strings (the parent schema doesn't advertise their types).
+        boolean keepConnected = asBoolean(parameters == null ? null : parameters.get("keep_connected"), true); //$NON-NLS-1$
+        boolean dryRun = asBoolean(parameters == null ? null : parameters.get("dry_run"), false); //$NON-NLS-1$
+        boolean async = asBoolean(parameters == null ? null : parameters.get("async"), false); //$NON-NLS-1$
 
         if (async && dryRun) {
             // Dry-run is fast and deterministic; running it synchronously avoids
@@ -239,5 +241,34 @@ public class EdtUpdateInfobaseTool extends AbstractTool {
 
     private static String asString(Object value) {
         return value == null ? null : String.valueOf(value).trim();
+    }
+
+    /**
+     * Coerces a JSON-decoded value into a boolean. Accepts {@link Boolean},
+     * canonical strings ({@code "true"}, {@code "false"}, case-insensitive,
+     * with surrounding whitespace ignored), and {@link Number} (non-zero ->
+     * true). Falls back to {@code defaultValue} on null/unrecognized input.
+     */
+    static boolean asBoolean(Object value, boolean defaultValue) {
+        if (value == null) {
+            return defaultValue;
+        }
+        if (value instanceof Boolean b) {
+            return b.booleanValue();
+        }
+        if (value instanceof Number n) {
+            return n.doubleValue() != 0d;
+        }
+        String s = String.valueOf(value).trim();
+        if (s.isEmpty()) {
+            return defaultValue;
+        }
+        if ("true".equalsIgnoreCase(s) || "1".equals(s)) { //$NON-NLS-1$ //$NON-NLS-2$
+            return true;
+        }
+        if ("false".equalsIgnoreCase(s) || "0".equals(s)) { //$NON-NLS-1$ //$NON-NLS-2$
+            return false;
+        }
+        return defaultValue;
     }
 }


### PR DESCRIPTION
## Проблема

```
edt_diagnostics command=update_infobase project_name=cf async=true
→ "The operation timed out."
```

В EDT апдейт реально запускается и идёт, но MCP-вызов не возвращает
`job_id` — клиент таймаутит. Контракт `async=true` — мгновенно отдать
`{job_id, state="running"}`, статус потом через `update_infobase_status`.

## Анализ

`EdtUpdateInfobaseTool.doExecute` парсит флаги через строгое
сравнение по типу:

```java
boolean async = parameters != null
        && Boolean.TRUE.equals(parameters.get("async"));
```

Когда вызов идёт через `edt_diagnostics`, родительская схема не
объявляет `async`/`dry_run`/`keep_connected` (там только
`command`/`project`/`project_name`/`tool_result` + `additionalProperties:true`).
LLM-клиент не видит типов и шлёт `async` JSON-строкой `"true"` вместо
JSON-булевого `true`. `Boolean.TRUE.equals("true")` → `false`,
async-флаг тихо теряется, идёт синхронный путь
(`CompletableFuture.supplyAsync` ждёт реального апдейта EDT), MCP-таймаут
120 с срабатывает раньше.

## Решение

Заменить три строгих сравнения на один lenient-хелпер:

```java
boolean keepConnected = asBoolean(get("keep_connected"), true);
boolean dryRun       = asBoolean(get("dry_run"),       false);
boolean async        = asBoolean(get("async"),         false);
```

`asBoolean(Object, boolean)` принимает `Boolean`, `Number`
(ненулевое → true), и канонические `"true"/"false"/"0"/"1"`
(case-insensitive, trim). Неузнанные значения — fallback на дефолт.

## Тест

`EdtUpdateInfobaseToolTest.async_stringTrue_returnsJobIdImmediately` —
вызов с `"async":"true"` (строка) против блокирующего runtime-стаба,
проверка возврата с `job_id` за <2 с и `state="RUNNING"`. Без фикса
тест зависает на блокирующем стабе, ассерт `elapsed < 2000` падает.

Существующий `async_true_returnsJobIdImmediately` (Boolean-путь)
продолжает работать — обе формы вызова закреплены.

## Test plan

- [ ] `mvn verify -Dtest=EdtUpdateInfobaseToolTest` → 5 тестов зелёные
- [ ] `mvn verify` полный реактор → BUILD SUCCESS (10 pre-existing падений не связаны)
- [ ] Live на EDT: `edt_diagnostics command=update_infobase async=true` → `{job_id, state:"RUNNING"}` за <5 с
