### PR TITLE
fix: findTopLevel не резолвит HTTPService — METADATA_NOT_FOUND в ensure_module_artifact и других FQN-операциях

### DIFF
--- a/bundles/com.codepilot1c.core/src/com/codepilot1c/core/edt/metadata/EdtMetadataService.java
+++ b/bundles/com.codepilot1c.core/src/com/codepilot1c/core/edt/metadata/EdtMetadataService.java
@@ -5239,6 +5239,7 @@ public class EdtMetadataService {
             case "dataprocessor", "обработка" -> configuration.getDataProcessors(); //$NON-NLS-1$ //$NON-NLS-2$
             case "constant", "константа" -> configuration.getConstants(); //$NON-NLS-1$ //$NON-NLS-2$
             case "subsystem", "subsystems", "подсистема" -> configuration.getSubsystems(); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+            case "httpservice", "httpсервис" -> configuration.getHttpServices(); //$NON-NLS-1$ //$NON-NLS-2$
             default -> Collections.emptyList();
         };
         for (MdObject object : topLevel) {


### PR DESCRIPTION
## Проблема

HTTP-сервисы не резолвятся по FQN: `findTopLevel` (в `resolveByFqn`) не имеет кейса `httpservice`, поэтому любая FQN-операция над HTTP-сервисом падает `METADATA_NOT_FOUND`, хотя объект существует.

Репро:
1. Заимствовать HTTP-сервис в расширение (`extension_manage adopt` — работает, у `EdtExtensionService` свой резолвер с кейсом `httpservice`).
2. `ensure_module_artifact object_fqn=HTTPService.<Имя> module_kind=module` → `[METADATA_NOT_FOUND] Metadata object not found: HTTPService.<Имя>`.

Затронуты все операции через `resolveByFqn`: `ensure_module_artifact`, `update_metadata`, `add_metadata_child` и т.д. При этом `mapTopFolder` HTTP-сервисы уже знает (`httpservice -> HTTPServices`), и в `EdtExtensionService` ровно такой кейс есть — пропущен только в `findTopLevel`.

## Фикс

Одна строка в switch `findTopLevel`:

```java
case "httpservice", "httpсервис" -> configuration.getHttpServices();
```

## Проверка

- Сборка зелёная (Tycho).
- Живой прогон на EDT 2025.2.3: на заимствованном в расширение HTTP-сервисе `ensure_module_artifact` до фикса — `METADATA_NOT_FOUND`, после — `Module artifact created successfully` (создан `src/HTTPServices/<Имя>/Module.bsl`); далее модуль с парой `&Вместо`-оверрайдов штатно компилируется конфигуратором.
- Юнит-тестов на кейс не добавлял — изменение симметрично соседним кейсам switch.
