### PR TITLE
feat: ValueTable как тип реквизита формы — платформенный резолв + размещение Table-элементом

### DIFF
--- a/bundles/com.codepilot1c.core/src/com/codepilot1c/core/edt/metadata/EdtMetadataService.java
+++ b/bundles/com.codepilot1c.core/src/com/codepilot1c/core/edt/metadata/EdtMetadataService.java
@@ -89,6 +89,7 @@ import com._1c.g5.v8.dt.form.model.UsualGroupExtInfo;
 import com._1c.g5.v8.dt.form.model.UsualGroupRepresentation;
 import com._1c.g5.v8.dt.form.model.FormItem;
 import com._1c.g5.v8.dt.form.model.FormItemContainer;
+import com._1c.g5.v8.dt.form.model.Table;
 import com._1c.g5.v8.dt.form.model.Titled;
 import com._1c.g5.v8.dt.form.model.Visible;
 import com._1c.g5.v8.dt.mcore.Command;
@@ -854,20 +855,44 @@ public class EdtMetadataService {
                     rejectTableIncompatibleFieldType(parentContainer, operation, name);
                     Map<String, Object> set = extractAddFieldSet(operation);
                     Integer index = asOptionalInteger(operation.get("index"), "index"); //$NON-NLS-1$ //$NON-NLS-2$
-                    FormField field = addFieldItem(
-                            formModel,
-                            parentContainer,
-                            operation,
-                            name,
-                            index,
-                            itemManagementService);
                     Map<String, Object> effectiveSet = stripMapKeysIgnoreCase(set, "name", "title"); //$NON-NLS-1$ //$NON-NLS-2$
-                    if (!effectiveSet.isEmpty()) {
-                        applyFormPropertySet(field, effectiveSet);
+                    FormAttribute valueTableAttribute = findValueTableFormAttribute(formModel, name);
+                    if (valueTableAttribute != null && itemManagementService != null) {
+                        // A ValueTable attribute must be rendered as a Table item with
+                        // column fields, not a flat FormField (which 1C cannot display).
+                        Table table = addTableItem(
+                                formModel,
+                                parentContainer,
+                                operation,
+                                name,
+                                index,
+                                itemManagementService);
+                        // Table binding is set in addTableItem (setDataPath); the
+                        // data-path / field-type keys are not Table properties and
+                        // would fail applyFormPropertySet ("Unknown form property").
+                        Map<String, Object> tableSet = stripMapKeysIgnoreCase(effectiveSet,
+                                "data_path", "datapath", "path", "type", "field_type", "fieldType"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$ //$NON-NLS-6$
+                        if (!tableSet.isEmpty()) {
+                            applyFormPropertySet(table, tableSet);
+                        }
+                        applyDefaultVisibility(table, tableSet);
+                        summaries.add("add_field[" + operationIndex + "]: name=" + table.getName() //$NON-NLS-1$ //$NON-NLS-2$
+                                + ", id=" + safeItemId(table) + " (ValueTable -> Table)"); //$NON-NLS-1$ //$NON-NLS-2$
+                    } else {
+                        FormField field = addFieldItem(
+                                formModel,
+                                parentContainer,
+                                operation,
+                                name,
+                                index,
+                                itemManagementService);
+                        if (!effectiveSet.isEmpty()) {
+                            applyFormPropertySet(field, effectiveSet);
+                        }
+                        applyDefaultVisibility(field, effectiveSet);
+                        summaries.add("add_field[" + operationIndex + "]: name=" + field.getName() + ", id=" //$NON-NLS-1$ //$NON-NLS-2$
+                                + safeItemId(field)); //$NON-NLS-1$
                     }
-                    applyDefaultVisibility(field, effectiveSet);
-                    summaries.add("add_field[" + operationIndex + "]: name=" + field.getName() + ", id=" //$NON-NLS-1$ //$NON-NLS-2$
-                            + safeItemId(field)); //$NON-NLS-1$
                 }
                 case "setitemprops", "setitem", "updateitem", "set" -> {
                     FormItem item = resolveRequiredItem(formModel, operation);
@@ -1074,6 +1099,62 @@ public class EdtMetadataService {
         applyTitleValue(field, getMapValueIgnoreCase(operation, "title")); //$NON-NLS-1$
         insertItemIntoContainer(parentContainer, field, index);
         return field;
+    }
+
+    /**
+     * Finds a form attribute by name whose value type is the platform
+     * {@code ValueTable} type. Such an attribute must be placed on the form as
+     * a {@link Table} item (with column fields), not a flat {@link FormField}.
+     */
+    private FormAttribute findValueTableFormAttribute(Form formModel, String attributeName) {
+        if (formModel == null || attributeName == null || attributeName.isBlank()) {
+            return null;
+        }
+        String token = normalizeToken(attributeName);
+        Set<String> valueTableQueries = Set.of("ValueTable", "ТаблицаЗначений"); //$NON-NLS-1$ //$NON-NLS-2$
+        for (FormAttribute attribute : formModel.getAttributes()) {
+            if (attribute == null || attribute.getName() == null) {
+                continue;
+            }
+            if (!normalizeToken(attribute.getName()).equals(token)) {
+                continue;
+            }
+            TypeDescription valueType = attribute.getValueType();
+            if (valueType == null) {
+                return null;
+            }
+            for (TypeItem typeItem : valueType.getTypes()) {
+                if (typeItem != null && matchesTypeRef(typeItem, valueTableQueries)) {
+                    return attribute;
+                }
+            }
+            return null;
+        }
+        return null;
+    }
+
+    /**
+     * Adds a {@link Table} item bound to a ValueTable form attribute via the
+     * EDT form item service, then materializes its column fields from the
+     * attribute's data path.
+     */
+    private Table addTableItem(
+            Form formModel,
+            FormItemContainer parentContainer,
+            Map<String, Object> operation,
+            String name,
+            Integer index,
+            IFormItemManagementService itemManagementService) {
+        FormNewItemDescriptor descriptor = buildFormNewItemDescriptor(operation, name);
+        DataPath dataPath = toDataPath(name, "data_path"); //$NON-NLS-1$
+        int insertAt = (index != null && index.intValue() >= 0
+                && index.intValue() <= parentContainer.getItems().size())
+                ? index.intValue()
+                : parentContainer.getItems().size();
+        Table table = itemManagementService.addTable(parentContainer, insertAt, formModel, descriptor);
+        table.setDataPath(dataPath);
+        itemManagementService.addTableFieldsByDataPath(table, dataPath, formModel, descriptor);
+        return table;
     }
 
     private FormCommand addCommandToForm(

--- a/bundles/com.codepilot1c.core/src/com/codepilot1c/core/edt/metadata/EdtMetadataService.java
+++ b/bundles/com.codepilot1c.core/src/com/codepilot1c/core/edt/metadata/EdtMetadataService.java
@@ -41,6 +41,10 @@ import org.eclipse.emf.ecore.EEnumLiteral;
 import org.eclipse.emf.ecore.EReference;
 import org.eclipse.emf.ecore.EStructuralFeature;
 import org.eclipse.emf.ecore.util.EcoreUtil;
+import org.eclipse.emf.ecore.resource.ResourceSet;
+import org.eclipse.xtext.resource.IEObjectDescription;
+import com._1c.g5.v8.dt.platform.IEObjectProvider;
+import com._1c.g5.v8.dt.platform.version.Version;
 
 import com._1c.g5.v8.bm.core.IBmCrossReference;
 import com._1c.g5.v8.bm.core.IBmEngine;
@@ -577,7 +581,7 @@ public class EdtMetadataService {
             Form formModel = resolveManagedFormModel(basicForm, applyFormFqn);
             applyFormRootPropertiesIfNeeded(basicForm, request);
             FormAttributeRecipeStats stats = hasAttributes
-                    ? applyFormAttributeRecipe(formModel, request.attributes(), mode, transaction, preResolvedTypes, txConfiguration)
+                    ? applyFormAttributeRecipe(project, formModel, request.attributes(), mode, transaction, preResolvedTypes, txConfiguration)
                     : new FormAttributeRecipeStats();
             List<String> summaries = hasLayoutOps
                     ? applyFormModelOperations(formModel, request.layoutOperations())
@@ -1919,6 +1923,7 @@ public class EdtMetadataService {
     }
 
     private FormAttributeRecipeStats applyFormAttributeRecipe(
+            IProject project,
             Form formModel,
             List<Map<String, Object>> attributes,
             FormRecipeMode mode,
@@ -2002,12 +2007,12 @@ public class EdtMetadataService {
                 created.setName(name);
                 FormAttributePatch patch = normalizeFormAttributePatch(descriptor);
                 if (patch.typeValue != null) {
-                    applyFormAttributeType(created, patch.typeValue, transaction, preResolvedTypes, txConfiguration);
+                    applyFormAttributeType(project, created, patch.typeValue, transaction, preResolvedTypes, txConfiguration);
                 }
                 applyFormAttributePatch(created, patch.patch);
                 formModel.getAttributes().add(created);
                 if (patch.columnsValue != null) {
-                    applyFormAttributeColumns(formModel, created, patch.columnsValue,
+                    applyFormAttributeColumns(project, formModel, created, patch.columnsValue,
                             transaction, preResolvedTypes, txConfiguration);
                 }
                 stats.created++;
@@ -2025,11 +2030,11 @@ public class EdtMetadataService {
             }
             FormAttributePatch patch = normalizeFormAttributePatch(descriptor);
             if (patch.typeValue != null) {
-                applyFormAttributeType(existing, patch.typeValue, transaction, preResolvedTypes, txConfiguration);
+                applyFormAttributeType(project, existing, patch.typeValue, transaction, preResolvedTypes, txConfiguration);
             }
             applyFormAttributePatch(existing, patch.patch);
             if (patch.columnsValue != null) {
-                applyFormAttributeColumns(formModel, existing, patch.columnsValue,
+                applyFormAttributeColumns(project, formModel, existing, patch.columnsValue,
                         transaction, preResolvedTypes, txConfiguration);
             }
             stats.updated++;
@@ -2100,6 +2105,7 @@ public class EdtMetadataService {
     }
 
     private void applyFormAttributeType(
+            IProject project,
             AbstractFormAttribute attribute,
             Object typeValue,
             IBmPlatformTransaction transaction,
@@ -2146,6 +2152,9 @@ public class EdtMetadataService {
                     txTypeItem = simple;
                 }
             }
+        }
+        if (txTypeItem == null) {
+            txTypeItem = resolveFormAttributeTypeFromPlatform(project, attribute, typeSpec, txConfiguration);
         }
         if (txTypeItem == null) {
             throw new MetadataOperationException(
@@ -2294,6 +2303,7 @@ public class EdtMetadataService {
      * for column value-type resolution.
      */
     private void applyFormAttributeColumns(
+            IProject project,
             Form formModel,
             FormAttribute attribute,
             Object columnsValue,
@@ -2352,8 +2362,97 @@ public class EdtMetadataService {
                 columnType = getMapValueIgnoreCase(spec, "fieldType"); //$NON-NLS-1$
             }
             if (columnType != null) {
-                applyFormAttributeType(column, columnType, transaction, preResolvedTypes, txConfiguration);
+                applyFormAttributeType(project, column, columnType, transaction, preResolvedTypes, txConfiguration);
             }
+        }
+    }
+
+    /**
+     * Resolves a platform value-type (ValueTable etc.) for a form attribute from
+     * the version-scoped platform type registry ({@link IEObjectProvider}). Used
+     * as a fallback when the BM/configuration resolvers cannot find the type
+     * (they only know metadata objects and primitives). This is the same
+     * mechanism {@code EdtPlatformDocumentationService} uses to enumerate
+     * built-in platform types; the configuration-scoped {@code TypeProviderService}
+     * does not expose platform value-types for a freshly created form attribute.
+     */
+    private TypeItem resolveFormAttributeTypeFromPlatform(
+            IProject project,
+            AbstractFormAttribute attribute,
+            TypeSpec typeSpec,
+            Configuration txConfiguration
+    ) {
+        if (attribute == null || typeSpec == null) {
+            return null;
+        }
+        Set<String> queries = expandTypeQueries(typeSpec.typeQuery());
+        if (queries.isEmpty()) {
+            return null;
+        }
+        Version version;
+        try {
+            version = gateway.resolvePlatformVersion(project);
+        } catch (RuntimeException e) {
+            LOG.debug("resolveFormAttributeTypeFromPlatform: no platform version: %s", e.getMessage()); //$NON-NLS-1$
+            return null;
+        }
+        if (version == null) {
+            return null;
+        }
+        IEObjectProvider.Registry registry = IEObjectProvider.Registry.INSTANCE;
+        IEObjectProvider provider = registry.get(McorePackage.Literals.TYPE_ITEM, version);
+        Iterable<IEObjectDescription> descriptions =
+                provider == null ? null : provider.getEObjectDescriptions(null);
+        if (descriptions == null || !descriptions.iterator().hasNext()) {
+            // Some platform versions expose only the TYPE provider.
+            provider = registry.get(McorePackage.Literals.TYPE, version);
+            descriptions = provider == null ? null : provider.getEObjectDescriptions(null);
+        }
+        if (descriptions == null) {
+            return null;
+        }
+        ResourceSet resourceSet = resolveModelResourceSet(project, attribute, txConfiguration);
+        if (resourceSet == null) {
+            return null;
+        }
+        for (IEObjectDescription description : descriptions) {
+            if (description == null) {
+                continue;
+            }
+            EObject candidate = description.getEObjectOrProxy();
+            if (candidate == null) {
+                continue;
+            }
+            EObject resolved = EcoreUtil.resolve(candidate, resourceSet);
+            if (resolved == null || resolved.eIsProxy()) {
+                continue;
+            }
+            if (resolved instanceof TypeItem typeItem && matchesTypeRef(typeItem, queries)) {
+                // Platform TypeItem is NOT a BM object; TypeDescription.types is
+                // non-containment (cross-resource reference). Do NOT call
+                // transaction.toTransactionObject() on it.
+                return typeItem;
+            }
+        }
+        return null;
+    }
+
+    private ResourceSet resolveModelResourceSet(
+            IProject project,
+            AbstractFormAttribute attribute,
+            Configuration txConfiguration
+    ) {
+        if (attribute != null && attribute.eResource() != null) {
+            return attribute.eResource().getResourceSet();
+        }
+        if (txConfiguration != null && txConfiguration.eResource() != null) {
+            return txConfiguration.eResource().getResourceSet();
+        }
+        try {
+            return gateway.getResourceSetProvider().get(project);
+        } catch (RuntimeException e) {
+            LOG.debug("resolveModelResourceSet: no resource set for project: %s", e.getMessage()); //$NON-NLS-1$
+            return null;
         }
     }
 
@@ -2369,14 +2468,13 @@ public class EdtMetadataService {
         executeRead(project, readTx -> {
             for (String typeString : typeStrings) {
                 TypeItem item = resolveTypeItem(typeString, readTx);
-                if (item == null && !isSimpleTypeQuery(typeString)) {
-                    throw new MetadataOperationException(
-                            MetadataOperationCode.INVALID_PROPERTY_VALUE,
-                            "Type not found in BM: " + typeString, false); //$NON-NLS-1$
-                }
                 if (item != null) {
                     cacheResolvedTypeItem(preResolvedTypes, typeString, item);
                 }
+                // BM miss for a non-simple type is not fatal here: it may be a platform
+                // value-type (ValueTable etc.) resolved later with form-attribute context
+                // by applyFormAttributeType's platform fallback. A genuinely invalid type
+                // still errors there ("Type value cannot be resolved for form attribute").
             }
             return null;
         });


### PR DESCRIPTION
## Проблема

Реквизит формы с типом `ТаблицаЗначений`/`ValueTable` сейчас не работает в две стороны:

1. **Создание реквизита** (`apply_form_recipe`, `attributes: [{type: "ТаблицаЗначений", ...}]`) — падает `Type value cannot be resolved for form attribute`: цепочка резолва (BM + config-scoped TypeProvider) не отдаёт платформенный value-тип для свежего in-tx атрибута.
2. **Размещение на форме** (`add_field` по такому реквизиту) — создаётся плоский `FormField`, который 1С для ValueTable не отображает; нужен элемент `Table` с колонками-полями.

## Что сделано

Два коммита, по одному на половину:

**1. Платформенный резолв типа** — fallback через version-scoped `IEObjectProvider.Registry` (тот же механизм, что в `EdtPlatformDocumentationService`): когда BM/TypeProvider не нашли тип, ищем `TypeItem` в платформенном реестре с резолвом прокси в `ResourceSet` модели. Важно: платформенный `TypeItem` — не BM-объект, `toTransactionObject` к нему не применяется (отражено комментарием). Заодно ослаблен pre-resolve (`preResolveAttributeTypes`): промах BM по не-простому типу больше не фатален на этапе предрезолва — финальная валидация остаётся в `applyFormAttributeType`.

**2. Рендеринг Table-элементом** — `add_field` распознаёт VT-реквизит (`findValueTableFormAttribute`) и строит `Table` через `IFormItemManagementService.addTable` + `addTableFieldsByDataPath` (колонки-поля материализуются по dataPath). `data_path`/`type`-ключи для Table отбрасываются из `applyFormPropertySet` — это не его свойства. Дополняет #49 (там — колонки при создании/обновлении реквизита и extInfo полей).

## Проверка

Живой сквозной прогон на EDT 2025.2.3: `apply_form_recipe` с `type:"ТаблицаЗначений"` и двумя колонками (`String(20)`, `Number(10,2)`) + `layout: [{op:"add_field", ...}]` на форме обработки. Результат в `.form`:

- реквизит: `<valueType><types>ValueTable</types></valueType>` + обе колонки с квалифаерами;
- элемент: `<items xsi:type="form:Table">` с dataPath реквизита и двумя дочерними `FormField` по dataPath колонок, автокоманднaя панель/поиск на месте;
- summary операции: `add_field[1]: ... (ValueTable -> Table)`.

Без фикса до этого воспроизводился именно отказ резолва типа (п.1), а при ручном обходе — плоский `FormField` (п.2).
