### PR TITLE
fix(forms): пересоздавать FieldExtInfo при несовпадении типа поля

### DIFF
--- a/bundles/com.codepilot1c.core/src/com/codepilot1c/core/edt/metadata/EdtMetadataService.java
+++ b/bundles/com.codepilot1c.core/src/com/codepilot1c/core/edt/metadata/EdtMetadataService.java
@@ -861,6 +861,7 @@ public class EdtMetadataService {
                     if (!effectiveSet.isEmpty()) {
                         applyFormPropertySet(field, effectiveSet);
                     }
+                    ensureFormFieldExtInfo(field);
                     applyDefaultVisibility(field, effectiveSet);
                     summaries.add("add_field[" + operationIndex + "]: name=" + field.getName() + ", id=" //$NON-NLS-1$ //$NON-NLS-2$
                             + safeItemId(field)); //$NON-NLS-1$
@@ -875,6 +876,9 @@ public class EdtMetadataService {
                     }
                     rejectTableAsSetItemType(operation, set, item);
                     applyFormPropertySet(item, set);
+                    if (item instanceof FormField) {
+                        ensureFormFieldExtInfo((FormField) item);
+                    }
                     summaries.add("set_item[" + operationIndex + "]: id=" + item.getId()); //$NON-NLS-1$ //$NON-NLS-2$
                 }
                 case "removeitem", "deleteitem" -> {
@@ -1424,9 +1428,6 @@ public class EdtMetadataService {
             return null;
         }
         FieldExtInfo existing = field.getExtInfo();
-        if (existing != null) {
-            return existing;
-        }
         ManagedFormFieldType type = field.getType();
         FieldExtInfo created = switch (type == null ? ManagedFormFieldType.INPUT_FIELD : type) {
             case LABEL_FIELD -> FormFactory.eINSTANCE.createLabelFieldExtInfo();
@@ -1450,6 +1451,9 @@ public class EdtMetadataService {
             case GRAPHICAL_SCHEMA_FIELD -> FormFactory.eINSTANCE.createFlowchartFieldExtInfo();
             default -> FormFactory.eINSTANCE.createInputFieldExtInfo();
         };
+        if (existing != null && existing.getClass() == created.getClass()) {
+            return existing;
+        }
         field.setExtInfo(created);
         return created;
     }


### PR DESCRIPTION
## Проблема

Поле формы с `field_type=HTML_DOCUMENT_FIELD` (через `add_field` / `apply_form_recipe`) создаётся с правильным `<type>HTMLDocumentField</type>`, но его `extInfo` остаётся `InputFieldExtInfo` (как у поля ввода) вместо `HtmlFieldExtInfo`. Из-за рассогласования платформа 1С отображает поле как поле ввода, а не как HTML-документ — на форме оно остаётся пустым.

## Причина

`EdtMetadataService.ensureFormFieldExtInfo` возвращал существующий `extInfo` без проверки соответствия типу поля:

```java
FieldExtInfo existing = field.getExtInfo();
if (existing != null) {
    return existing;   // ранний возврат: чужой InputFieldExtInfo сохраняется
}
```

EDT item-management service сначала создаёт поле с дефолтным `InputFieldExtInfo`, затем тип меняется на `HTMLDocumentField` — но `ensureFormFieldExtInfo` уже не пересоздаёт `extInfo`. Для групп аналогичный метод `ensureFormGroupExtInfo` корректно пересоздаёт `extInfo` по типу через проверку `instanceof`; для полей такой проверки не было.

## Исправление

- `ensureFormFieldExtInfo`: пересоздаёт `extInfo`, когда класс существующего не совпадает с типом поля (по аналогии с `ensureFormGroupExtInfo`); если existing уже нужного класса — сохраняется как есть, без потери данных.
- `add_field`: вызывает `ensureFormFieldExtInfo` после применения типа поля.
- `set_item`: то же для `FormField` при смене типа.

Бонусом чинится установка свойств `HtmlFieldExtInfo` (`horizontalStretch` и др.) через `set_item`: fallback `applyFormPropertySet -> ensureFormFieldExtInfo` теперь резолвит их на корректном extInfo.

## Проверка

Изолированный paired-eval (7 кейсов, чистая Java): старый код оставляет `InputFieldExtInfo` на HTML-поле, новый ставит `HtmlFieldExtInfo`, корректный существующий extInfo сохраняется, регрессий нет. Плагин собирается (`mvn -DskipTests package`); на собранной сборке пересоздание HTML-поля даёт `<extInfo xsi:type="form:HtmlFieldExtInfo">`, поле отображает HTML.

Полный CI с юнит-тестами локально не прогонял — фикс точечный, затрагивает только `EdtMetadataService`.