### PR TITLE
feat(forms): операция add_handler для обработчиков событий формы

### DIFF
--- a/bundles/com.codepilot1c.core/src/com/codepilot1c/core/edt/metadata/EdtMetadataService.java
+++ b/bundles/com.codepilot1c.core/src/com/codepilot1c/core/edt/metadata/EdtMetadataService.java
@@ -88,6 +88,8 @@ import com._1c.g5.v8.dt.form.model.FormItemContainer;
 import com._1c.g5.v8.dt.form.model.Titled;
 import com._1c.g5.v8.dt.form.model.Visible;
 import com._1c.g5.v8.dt.mcore.Command;
+import com._1c.g5.v8.dt.mcore.Event;
+import com._1c.g5.v8.dt.form.model.EventHandler;
 import com._1c.g5.v8.dt.form.service.item.FormNewItemDescriptor;
 import com._1c.g5.v8.dt.form.service.item.IFormItemManagementService;
 import com._1c.g5.v8.dt.mcore.DateQualifiers;
@@ -965,6 +967,55 @@ public class EdtMetadataService {
                     summaries.add("add_button[" + operationIndex + "]: name=" + button.getName() //$NON-NLS-1$ //$NON-NLS-2$
                             + ", id=" + safeItemId(button) //$NON-NLS-1$
                             + (commandRef != null ? ", command=" + commandRef : "")); //$NON-NLS-1$ //$NON-NLS-2$
+                }
+                case "addhandler", "add_handler", "addeventhandler", "set_handler" -> { //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+                    String event = asString(getMapValueIgnoreCase(operation, "event")); //$NON-NLS-1$
+                    if (event == null || event.isBlank()) {
+                        throw new MetadataOperationException(
+                                MetadataOperationCode.INVALID_METADATA_CHANGE,
+                                "add_handler requires 'event' (e.g. OnCreateAtServer)", false); //$NON-NLS-1$
+                    }
+                    String handlerName = asString(getMapValueIgnoreCase(operation, "name")); //$NON-NLS-1$
+                    if (handlerName == null || handlerName.isBlank()) {
+                        handlerName = event;
+                    }
+                    Event targetEvent = null;
+                    for (Event ev : formModel.getFormEvents()) {
+                        if (ev != null && event.equalsIgnoreCase(ev.getName())) {
+                            targetEvent = ev;
+                            break;
+                        }
+                    }
+                    if (targetEvent == null) {
+                        java.util.List<String> available = new java.util.ArrayList<>();
+                        for (Event ev : formModel.getFormEvents()) {
+                            if (ev != null) {
+                                available.add(ev.getName());
+                            }
+                        }
+                        throw new MetadataOperationException(
+                                MetadataOperationCode.METADATA_NOT_FOUND,
+                                "Form event not found: " + event + ". Available: " + String.join(", ", available), false); //$NON-NLS-1$ //$NON-NLS-2$
+                    }
+                    EventHandler existingHandler = null;
+                    for (EventHandler h : formModel.getHandlers()) {
+                        if (h != null && h.getEvent() == targetEvent) {
+                            existingHandler = h;
+                            break;
+                        }
+                    }
+                    if (existingHandler != null) {
+                        existingHandler.setName(handlerName);
+                        summaries.add("add_handler[" + operationIndex + "]: event=" + event //$NON-NLS-1$ //$NON-NLS-2$
+                                + ", name=" + handlerName + " (updated)"); //$NON-NLS-1$ //$NON-NLS-2$
+                    } else {
+                        EventHandler handler = FormFactory.eINSTANCE.createEventHandler();
+                        handler.setEvent(targetEvent);
+                        handler.setName(handlerName);
+                        formModel.getHandlers().add(handler);
+                        summaries.add("add_handler[" + operationIndex + "]: event=" + event //$NON-NLS-1$ //$NON-NLS-2$
+                                + ", name=" + handlerName); //$NON-NLS-1$ //$NON-NLS-2$
+                    }
                 }
                 default -> throw new MetadataOperationException(
                         MetadataOperationCode.INVALID_METADATA_CHANGE,

--- a/bundles/com.codepilot1c.core/src/com/codepilot1c/core/tools/forms/MutateFormModelTool.java
+++ b/bundles/com.codepilot1c.core/src/com/codepilot1c/core/tools/forms/MutateFormModelTool.java
@@ -47,13 +47,13 @@ public class MutateFormModelTool extends AbstractTool {
                     "properties": {
                       "op": {
                         "type": "string",
-                        "description": "Тип операции: set_form_props/add_group/add_field/add_command/add_button/set_item/remove_item/move_item"
+                        "description": "Тип операции: set_form_props/add_group/add_field/add_command/add_button/add_handler/set_item/remove_item/move_item"
                       }
                     },
                     "required": ["op"],
                     "additionalProperties": true
                   },
-                  "description": "Список операций: set_form_props/add_group/add_field/add_command/add_button/set_item/remove_item/move_item. add_command: name+action (handler). add_button: name+command_name+parent_item_id."
+                  "description": "Список операций: set_form_props/add_group/add_field/add_command/add_button/add_handler/set_item/remove_item/move_item. add_command: name+action (handler). add_button: name+command_name+parent_item_id. add_handler: привязка обработчика СОБЫТИЯ формы — {op:add_handler, event:OnCreateAtServer, name:ПриСозданииНаСервере}."
                 },
                 "validation_token": {
                   "type": "string",


### PR DESCRIPTION
## Проблема

`mutate_form_model` не регистрирует обработчики событий формы (`OnCreateAtServer` и др.). Форма, созданная через инструмент, не получает секцию `<handlers>` — поэтому процедуры-обработчики (например `ПриСозданииНаСервере`) присутствуют в модуле, но платформой 1С не вызываются. Форма открывается, но реквизиты, заполняемые в обработчике, остаются пустыми.

## Причина

`mutate_form_model` регистрировал только обработчики команд (`CommandHandler` через `add_command` / `add_button`). Операции для привязки события формы к процедуре не было, а `set_form_props` отвергает `handlers` напрямую (`Reference property updates are not supported directly: handlers`).

## Исправление

Новая операция `add_handler`:
- находит событие в `Form.getFormEvents()` по имени (`event`, регистронезависимо);
- создаёт `EventHandler` через `FormFactory.createEventHandler()`;
- привязывает `setEvent` + `setName`, добавляет в `form.getHandlers()`;
- идемпотентна: при уже существующем обработчике события обновляет имя;
- при ненайденном событии возвращает список доступных событий формы.

Алиасы op: `add_handler` / `addhandler` / `addeventhandler` / `set_handler`.

Пример:
```
{"op":"add_handler","event":"OnCreateAtServer","name":"ПриСозданииНаСервере"}
```

## Проверка

Сборка `mvn -DskipTests package` — BUILD SUCCESS (EDT API подтверждён компиляцией: `getFormEvents` / `createEventHandler` / `getHandlers`). На собранной сборке операция привязала обработчик к форме обработки: `.form` получил `<handlers><event>OnCreateAtServer</event><name>ПриСозданииНаСервере</name></handlers>`, после чего процедура стала вызываться.

Полный CI с юнит-тестами локально не прогонял — изменение точечное, затрагивает только `EdtMetadataService`.