### PR TITLE
fix(edt): NPE update_infobase — обработка callback resolveInfobaseChanges (EDT 2025.2.3)

### DIFF
--- a/bundles/com.codepilot1c.core/src/com/codepilot1c/core/edt/runtime/EdtRuntimeService.java
+++ b/bundles/com.codepilot1c.core/src/com/codepilot1c/core/edt/runtime/EdtRuntimeService.java
@@ -510,33 +510,37 @@ public class EdtRuntimeService {
                 loader);
         return Proxy.newProxyInstance(callbackInterface.getClassLoader(),
                 new Class<?>[] { callbackInterface },
-                (Object proxy, Method method, Object[] args) -> handleUpdateCallback(method, args));
+                (Object proxy, Method method, Object[] args) -> handleUpdateCallback(proxy, method, args));
     }
 
-    @SuppressWarnings("unchecked")
-    private static Object handleUpdateCallback(Method method, Object[] args) throws Exception {
+    private static Object handleUpdateCallback(Object proxy, Method method, Object[] args) {
         String name = method.getName();
         if ("onConfirm".equals(name)) { //$NON-NLS-1$
             return Boolean.TRUE;
         }
-        if ("onInfobaseChanges".equals(name)) { //$NON-NLS-1$
-            if (args == null || args.length < 7) {
-                return enumValue(method.getReturnType(), "DEFERRED"); //$NON-NLS-1$
+        // EDT 2025.2.x вызывает resolveInfobaseChanges (унаследован из IInfobaseChangesResolver);
+        // прежнее имя onInfobaseChanges оставлено как legacy-alias на случай других версий API.
+        // Для headless-обновления политика — «проект перезаписывает ИБ»: возвращаем OVERRIDDEN
+        // (как GUI-callback при allowOverrideConflict), НЕ вызывая resolver.overrideConflict —
+        // он требует IUpdateInfobaseFlow, которого в аргументах resolveInfobaseChanges нет.
+        if ("resolveInfobaseChanges".equals(name) || "onInfobaseChanges".equals(name)) { //$NON-NLS-1$ //$NON-NLS-2$
+            Object overridden = enumValue(method.getReturnType(), "OVERRIDDEN"); //$NON-NLS-1$
+            if (overridden != null) {
+                return overridden;
             }
-            Object conflictResolver = args[4];
-            if (conflictResolver == null) {
-                return enumValue(method.getReturnType(), "DEFERRED"); //$NON-NLS-1$
-            }
-            Method override = findMethod(conflictResolver.getClass(), "overrideConflict", 6); //$NON-NLS-1$
-            if (override != null) {
-                return override.invoke(conflictResolver, args[0], args[1], args[2], args[3], args[5], args[6]);
-            }
-            return enumValue(method.getReturnType(), "DEFERRED"); //$NON-NLS-1$
+            Object deferred = enumValue(method.getReturnType(), "DEFERRED"); //$NON-NLS-1$
+            return deferred != null ? deferred : defaultValue(method.getReturnType());
         }
-        if ("toString".equals(name)) { //$NON-NLS-1$
+        if ("toString".equals(name) && method.getParameterCount() == 0) { //$NON-NLS-1$
             return "AutoUpdateCallbackProxy"; //$NON-NLS-1$
         }
-        return null;
+        if ("hashCode".equals(name) && method.getParameterCount() == 0) { //$NON-NLS-1$
+            return Integer.valueOf(System.identityHashCode(proxy));
+        }
+        if ("equals".equals(name) && method.getParameterCount() == 1) { //$NON-NLS-1$
+            return Boolean.valueOf(args != null && args.length == 1 && proxy == args[0]);
+        }
+        return defaultValue(method.getReturnType());
     }
 
     private static Method findUpdateMethod(Class<?> managerClass) {
@@ -555,7 +559,42 @@ public class EdtRuntimeService {
     @SuppressWarnings("unchecked")
     private static Object enumValue(Class<?> type, String name) {
         if (type != null && type.isEnum()) {
-            return Enum.valueOf((Class<Enum>) type, name);
+            try {
+                return Enum.valueOf((Class<Enum>) type, name);
+            } catch (IllegalArgumentException e) {
+                return null;
+            }
+        }
+        return null;
+    }
+
+    private static Object defaultValue(Class<?> type) {
+        if (type == null || type == Void.TYPE || !type.isPrimitive()) {
+            return null;
+        }
+        if (type == Boolean.TYPE) {
+            return Boolean.FALSE;
+        }
+        if (type == Character.TYPE) {
+            return Character.valueOf('\0');
+        }
+        if (type == Byte.TYPE) {
+            return Byte.valueOf((byte) 0);
+        }
+        if (type == Short.TYPE) {
+            return Short.valueOf((short) 0);
+        }
+        if (type == Integer.TYPE) {
+            return Integer.valueOf(0);
+        }
+        if (type == Long.TYPE) {
+            return Long.valueOf(0L);
+        }
+        if (type == Float.TYPE) {
+            return Float.valueOf(0F);
+        }
+        if (type == Double.TYPE) {
+            return Double.valueOf(0D);
         }
         return null;
     }


### PR DESCRIPTION
## Суть

`edt_diagnostics update_infobase` бросает NPE при любом конфликте конфигурации ИБ против EDT-проекта:

```
Cannot invoke "...InfobaseConflictResolutionResult.ordinal()" because "conflictResolutionResult" is null
```

## Причина

`EdtRuntimeService.handleUpdateCallback` ловит имя метода callback `"onInfobaseChanges"`, но в
EDT 2025.2.x фактический метод — `IInfobaseChangesResolver.resolveInfobaseChanges(...)`
(унаследован в `IInfobaseUpdateCallback`). Имя не совпадает, поэтому динамический прокси падает в
`return null`; EDT затем вызывает `InfobaseConflictResolutionResult.ordinal()` на этом null → NPE
при каждом конфликте. В той же ветке устаревшая сигнатура: `overrideConflict` с arity 6 (реально 8),
resolver на `args[4]` (реально `args[5]`).

## Исправление

- Обрабатывать `resolveInfobaseChanges` (`onInfobaseChanges` оставлен legacy-алиасом).
- Для headless-обновления возвращать `OVERRIDDEN` (политика «проект перезаписывает ИБ» — тот же путь,
  что у GUI-callback при `allowOverrideConflict`). Намеренно **не** вызываем `resolver.overrideConflict(...)`:
  ему нужен `IUpdateInfobaseFlow`, которого нет среди аргументов `resolveInfobaseChanges`
  (есть только `IInfobaseSynchronizationFlow`).
- Надёжность: корректные `Object`-методы прокси (`equals`/`hashCode`), `enumValue` с try/catch и хелпер
  `defaultValue`, чтобы прокси не возвращал null для callback-метода с примитивным типом возврата.

## Проверка

- Изолированный paired-eval логики callback: старый код возвращает `null` (воспроизводит NPE), новый
  возвращает `OVERRIDDEN`; `onConfirm` не затронут.
- Живой `update_infobase` на файловой ИБ EDT 2025.2.3 возвращает `updated: true` (раньше был NPE).

Сигнатуры подтверждены через `javap` по плагинам EDT 2025.2.3: `IInfobaseUpdateCallback`,
`IInfobaseChangesResolver`, `IInfobaseUpdateConflictResolver`, `InfobaseConflictResolutionResult`
= {DEFERRED, IMPORTED, OVERRIDDEN, IGNORED}.
