### PR TITLE
fix(tools): синхронизировать BM после write_file/edit_file

### DIFF
--- a/bundles/com.codepilot1c.core/src/com/codepilot1c/core/edt/ast/BmSyncHelper.java
+++ b/bundles/com.codepilot1c.core/src/com/codepilot1c/core/edt/ast/BmSyncHelper.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2024 Example
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, version 3.
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package com.codepilot1c.core.edt.ast;
+
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IProject;
+
+import com._1c.g5.v8.derived.IDerivedDataManager;
+import com._1c.g5.v8.dt.core.platform.IDerivedDataManagerProvider;
+import com._1c.g5.v8.dt.core.platform.IDtProject;
+import com._1c.g5.v8.dt.core.platform.IDtProjectManager;
+import com.codepilot1c.core.logging.VibeLogger;
+
+/**
+ * Flushes EDT derived-data (BM) after a programmatic file write.
+ *
+ * <p>Problem this solves: {@code write_file}/{@code edit_file} write {@code .bsl}
+ * content through {@link IFile#setContents}, which is correct at the workspace
+ * level, but EDT recomputes its in-memory Business Model (BM) and other derived
+ * data <em>asynchronously</em> in background jobs. If the tool returns immediately
+ * after {@code setContents}/{@code refreshLocal}, a subsequent BM-backed read
+ * (e.g. {@code bsl_get_method_body}) or {@code update_infobase} sees stale content
+ * until EDT is restarted (a restart forces a full reparse from disk).</p>
+ *
+ * <p>Fix: after the write, block on
+ * {@link IDerivedDataManager#waitImportantDataComputations(long)} for the affected
+ * project so the BM is consistent before the tool returns. This mirrors the
+ * existing pattern in {@code EdtTraceExportTool#flushDerivedData}.</p>
+ *
+ * <p>Best-effort: any failure (service not yet available, non-EDT project,
+ * interruption) is swallowed/logged and never propagated — the file is already
+ * written, so a sync hiccup must not turn a successful write into a failure.</p>
+ */
+public final class BmSyncHelper {
+
+    private static final VibeLogger.CategoryLogger LOG = VibeLogger.forClass(BmSyncHelper.class);
+
+    /** Upper bound for the BM recompute wait. Normal single-module recompute is sub-second. */
+    public static final long DEFAULT_WAIT_MS = 30_000L;
+
+    private BmSyncHelper() {
+    }
+
+    /**
+     * Waits for EDT derived-data (BM) recomputation triggered by a write to {@code file},
+     * using {@link #DEFAULT_WAIT_MS}.
+     *
+     * @param file the file that was just written (may be {@code null})
+     * @return {@code true} if derived data finished computing (or there was nothing to wait
+     *         for); {@code false} if the wait timed out or was skipped
+     */
+    public static boolean flushAfterWrite(IFile file) {
+        return flushAfterWrite(file, DEFAULT_WAIT_MS);
+    }
+
+    /**
+     * Waits for EDT derived-data (BM) recomputation triggered by a write to {@code file}.
+     *
+     * @param file   the file that was just written (may be {@code null})
+     * @param waitMs maximum time to wait, in milliseconds
+     * @return {@code true} if derived data finished computing (or there was nothing to wait
+     *         for); {@code false} if the wait timed out or was skipped
+     */
+    public static boolean flushAfterWrite(IFile file, long waitMs) {
+        if (file == null) {
+            return false;
+        }
+        try {
+            IProject project = file.getProject();
+            if (project == null || !project.isOpen()) {
+                return false;
+            }
+
+            EdtServiceGateway gateway = new EdtServiceGateway();
+            IDtProjectManager projectManager = gateway.getDtProjectManager();
+            IDtProject dtProject = projectManager.getDtProject(project);
+            if (dtProject == null) {
+                // Not an EDT project (or not yet imported) — nothing to flush.
+                return true;
+            }
+
+            IDerivedDataManagerProvider provider = gateway.getDerivedDataManagerProvider();
+            IDerivedDataManager ddManager = provider.get(dtProject);
+            if (ddManager == null) {
+                LOG.debug("BmSyncHelper: derived-data manager unavailable for %s", //$NON-NLS-1$
+                        file.getFullPath());
+                return false;
+            }
+
+            boolean done = ddManager.waitImportantDataComputations(waitMs);
+            if (!done) {
+                LOG.warn("BmSyncHelper: derived-data wait timed out after %d ms for %s; BM may lag until next recompute", //$NON-NLS-1$
+                        waitMs, file.getFullPath());
+            } else {
+                LOG.debug("BmSyncHelper: BM synced after write to %s", file.getFullPath()); //$NON-NLS-1$
+            }
+            return done;
+        } catch (InterruptedException ie) {
+            Thread.currentThread().interrupt();
+            LOG.debug("BmSyncHelper: interrupted while waiting for BM sync of %s", //$NON-NLS-1$
+                    file.getFullPath());
+            return false;
+        } catch (RuntimeException e) {
+            // EdtServiceGateway throws EdtAstException (unchecked) when EDT services are not
+            // yet available; treat as best-effort and never fail the originating write.
+            LOG.debug("BmSyncHelper: flush skipped for %s: %s", //$NON-NLS-1$
+                    file.getFullPath(), e.getMessage());
+            return false;
+        }
+    }
+}

--- a/bundles/com.codepilot1c.core/src/com/codepilot1c/core/tools/file/EditFileTool.java
+++ b/bundles/com.codepilot1c.core/src/com/codepilot1c/core/tools/file/EditFileTool.java
@@ -34,6 +34,7 @@ import com.codepilot1c.core.edit.FileEditApplier;
 import com.codepilot1c.core.edit.FuzzyMatcher;
 import com.codepilot1c.core.edit.MatchResult;
 import com.codepilot1c.core.edit.SearchReplaceFormat;
+import com.codepilot1c.core.edt.ast.BmSyncHelper;
 import com.codepilot1c.core.logging.LogSanitizer;
 import com.codepilot1c.core.logging.VibeLogger;
 
@@ -189,6 +190,14 @@ public class EditFileTool extends AbstractTool {
                     LOG.warn("edit_file: недостаточно параметров для редактирования"); //$NON-NLS-1$
                     return ToolResult.failure(
                             "Either 'content', 'edits', or both 'old_text' and 'new_text' are required"); //$NON-NLS-1$
+                }
+
+                if (result.isSuccess()) {
+                    // Wait for EDT to recompute derived data (BM) for this project, so
+                    // subsequent BM-backed operations (bsl_get_method_body, update_infobase,
+                    // ...) see the edit without requiring an EDT restart. Covers all write
+                    // paths above (replace / search-replace / fuzzy / edit-blocks).
+                    BmSyncHelper.flushAfterWrite(file);
                 }
 
                 LOG.debug("edit_file: завершено за %s, success=%b", //$NON-NLS-1$

--- a/bundles/com.codepilot1c.core/src/com/codepilot1c/core/tools/file/WriteTool.java
+++ b/bundles/com.codepilot1c.core/src/com/codepilot1c/core/tools/file/WriteTool.java
@@ -10,6 +10,7 @@ import com.codepilot1c.core.tools.ToolResult;
 import com.codepilot1c.core.tools.ToolParameters;
 import com.codepilot1c.core.tools.ToolMeta;
 import com.codepilot1c.core.tools.AbstractTool;
+import com.codepilot1c.core.edt.ast.BmSyncHelper;
 
 import java.io.ByteArrayInputStream;
 import java.nio.charset.StandardCharsets;
@@ -182,12 +183,19 @@ public class WriteTool extends AbstractTool {
         // Refresh
         file.refreshLocal(IResource.DEPTH_ZERO, new NullProgressMonitor());
 
+        // Wait for EDT to recompute derived data (BM) for this project, so subsequent
+        // BM-backed operations (bsl_get_method_body, update_infobase, ...) see the new
+        // content without requiring an EDT restart.
+        boolean bmSynced = BmSyncHelper.flushAfterWrite(file);
+
         // Build result
         StringBuilder result = new StringBuilder();
         result.append("**Файл обновлен:** `").append(file.getFullPath()).append("`\n");
         result.append("**Размер:** ").append(bytes.length).append(" байт\n");
         result.append("**Строк:** ").append(countLines(content)).append("\n");
-        result.append("**Статус:** перезаписан");
+        result.append("**Статус:** перезаписан\n");
+        result.append("**BM-синхронизация:** ")
+                .append(bmSynced ? "готово" : "не подтверждена (модель может отставать)");
 
         logInfo("Файл обновлен: " + file.getFullPath());
 


### PR DESCRIPTION
## Проблема

`write_file` / `edit_file` пишут содержимое через `IFile.setContents(...)` корректно, но пересборка derived data (BM) в EDT асинхронна. Сразу после записи BM-зависимые операции (`bsl_get_method_body`, `update_infobase`, ...) читают устаревшую модель — до перезапуска EDT.

## Фикс

`BmSyncHelper.flushAfterWrite(file)` — после успешной записи дожидается `IDerivedDataManager.waitImportantDataComputations()` для проекта файла (тот же механизм, что уже используется в `EdtTraceExportTool`). Подключено:

- `WriteTool` — плюс строка статуса в ответе: `BM-синхронизация: готово / не подтверждена (модель может отставать)`;
- `EditFileTool` — один вызов после успешного результата, покрывает все пути записи (replace / SEARCH-REPLACE / fuzzy).

Таймаут ожидания ограничен, при сбое синхронизации запись НЕ откатывается — инструмент лишь честно сообщает состояние модели.

## Проверка

Проверено эмпирически (EDT 2025.2.3): `write_file`/`edit_file` → сразу `bsl_get_method_body` видит новый код без перезапуска EDT. Используются только API `IDerivedDataManager` / `IDtProjectManager`, уже задействованные в `EdtTraceExportTool`.