### PR TITLE
fix(forms): create_form заполняет usePurposes формы (PersonalComputer+MobileDevice)

### DIFF
--- a/bundles/com.codepilot1c.core/src/com/codepilot1c/core/edt/metadata/EdtMetadataService.java
+++ b/bundles/com.codepilot1c.core/src/com/codepilot1c/core/edt/metadata/EdtMetadataService.java
@@ -101,6 +101,7 @@ import com._1c.g5.v8.dt.mcore.StringQualifiers;
 import com._1c.g5.v8.dt.mcore.TypeDescription;
 import com._1c.g5.v8.dt.mcore.TypeItem;
 import com._1c.g5.v8.dt.mcore.util.McoreUtil;
+import com._1c.g5.v8.dt.metadata.common.ApplicationUsePurpose;
 import com._1c.g5.v8.dt.metadata.mdclass.BasicFeature;
 import com._1c.g5.v8.dt.metadata.mdclass.BasicForm;
 import com._1c.g5.v8.dt.metadata.mdclass.BasicTemplate;
@@ -4531,6 +4532,13 @@ public class EdtMetadataService {
         }
         if (basicForm.getFormType() == null) {
             basicForm.setFormType(FormType.MANAGED);
+        }
+        // The platform treats an empty usePurposes list as "no purposes": the server
+        // part of an extension form is silently not activated (OnCreateAtServer is
+        // never called). EDT UI always creates forms with both purposes set.
+        if (basicForm.getUsePurposes().isEmpty()) {
+            basicForm.getUsePurposes().add(ApplicationUsePurpose.PERSONAL_COMPUTER);
+            basicForm.getUsePurposes().add(ApplicationUsePurpose.MOBILE_DEVICE);
         }
     }
 


### PR DESCRIPTION
## Проблема

`create_form` создаёт `BasicForm` с пустым `usePurposes`. Платформа трактует пустой список как «ни одного назначения»: серверная часть формы **расширения** молча не активируется — `ПриСозданииНаСервере` не вызывается, серверные вызовы команд формы не связываются. Ошибок и диагностики нет, форма просто «мёртвая» на сервере.

EDT UI при создании формы всегда проставляет `PersonalComputer` + `MobileDevice`.

## Фикс

В `initializeFormIfNeeded` при пустом `getUsePurposes()` добавляются `ApplicationUsePurpose.PERSONAL_COMPUTER` + `MOBILE_DEVICE` — покрывает оба пути создания (`create_form` и `add_metadata_child` с kind FORM). Непустой список не трогается.

## Проверка

- Paired-eval (4 кейса, javac): старый код оставляет `usePurposes=[]` на свежей форме, новый ставит оба назначения; заполненный список не перезаписывается; не-форма — no-op.
- Живьём на своём форке (тот же дифф): `.mdo` владельца после `create_form` получает `<usePurposes>PersonalComputer</usePurposes><usePurposes>MobileDevice</usePurposes>`, серверные обработчики формы расширения начинают вызываться.
