### PR TITLE
fix(forms): дефолты геометрии для нового HtmlFieldExtInfo

### DIFF
--- a/bundles/com.codepilot1c.core/src/com/codepilot1c/core/edt/metadata/EdtMetadataService.java
+++ b/bundles/com.codepilot1c.core/src/com/codepilot1c/core/edt/metadata/EdtMetadataService.java
@@ -70,6 +70,7 @@ import com._1c.g5.v8.dt.form.model.FormCommandHandlerContainer;
 import com._1c.g5.v8.dt.form.model.FormFactory;
 import com._1c.g5.v8.dt.form.model.FormField;
 import com._1c.g5.v8.dt.form.model.FieldExtInfo;
+import com._1c.g5.v8.dt.form.model.HtmlFieldExtInfo;
 import com._1c.g5.v8.dt.form.model.ManagedFormFieldType;
 import com._1c.g5.v8.dt.form.model.ButtonGroupExtInfo;
 import com._1c.g5.v8.dt.form.model.CommandBarExtInfo;
@@ -1450,6 +1451,18 @@ public class EdtMetadataService {
             case GRAPHICAL_SCHEMA_FIELD -> FormFactory.eINSTANCE.createFlowchartFieldExtInfo();
             default -> FormFactory.eINSTANCE.createInputFieldExtInfo();
         };
+        if (created instanceof HtmlFieldExtInfo htmlFieldExtInfo) {
+            // A bare HtmlFieldExtInfo (EMF defaults: width/height 0, stretch false)
+            // survives the EDT model, but the EDT->Designer conversion serializes
+            // Width=0/Height=0/Stretch=false and the platform renders the field
+            // invisible. Mirror the geometry the EDT UI sets for a new HTML field.
+            htmlFieldExtInfo.setWidth(50);
+            htmlFieldExtInfo.setHeight(10);
+            htmlFieldExtInfo.setAutoMaxWidth(true);
+            htmlFieldExtInfo.setAutoMaxHeight(true);
+            htmlFieldExtInfo.setHorizontalStretch(true);
+            htmlFieldExtInfo.setVerticalStretch(true);
+        }
         field.setExtInfo(created);
         return created;
     }


### PR DESCRIPTION
## Проблема

`add_field field_type=HTML_DOCUMENT_FIELD` оставляет `HtmlFieldExtInfo` с EMF-дефолтами (width/height = 0, stretch = false). В EDT-модели это выживает, но конвертация EDT→Designer сериализует `Width=0/Height=0/Stretch=false` — платформа рендерит поле **невидимым**, тихо и без диагностики (плюс EDT-валидация даёт SU2 «value must be greater than zero» на форме).

## Фикс

`ensureFormFieldExtInfo`: при создании нового `HtmlFieldExtInfo` проставляется геометрия, которую ставит EDT UI для нового HTML-поля: `width=50, height=10, autoMaxWidth/autoMaxHeight=true, horizontalStretch/verticalStretch=true`. Существующий extInfo не трогается — пользовательская геометрия сохраняется.

Дополняет #59: с recreate-on-mismatch дефолты применяются и когда item-service изначально поставил extInfo не того класса.

## Проверка

- Paired-eval (5 кейсов, javac): старый код даёт нулевую геометрию на обоих сценариях (свежее поле и поле с extInfo не того класса), новый — дефолты EDT UI; пользовательские width/height существующего extInfo не перезаписываются.
- Живьём на своём форке (тот же дифф): `.form` после add_field содержит полную геометрию, поле видимо в Предприятии.
