### PR TITLE
docs: относительные пути вместо машинно-специфичных в README

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,17 +79,17 @@ tools/run-edt-e2e-local.sh
 Если нужно прогонять простые coding-задачи через внешний implementer, а затем автоматически отправлять diff на review в `codex` и возвращать найденные дефекты обратно в тот же session, используйте один из wrappers:
 
 ```bash
-bash /Users/alexorlik/repo/codepilot1c-oss/tools/run-qwen-codex-flow.sh /abs/path/to/task.md
-bash /Users/alexorlik/repo/codepilot1c-oss/tools/run-claude-codex-flow.sh /abs/path/to/task.md
+bash tools/run-qwen-codex-flow.sh /abs/path/to/task.md
+bash tools/run-claude-codex-flow.sh /abs/path/to/task.md
 ```
 
 или через stdin:
 
 ```bash
 echo "Fix the failing test in MetadataSyncService and keep the scope minimal." \
-  | bash /Users/alexorlik/repo/codepilot1c-oss/tools/run-qwen-codex-flow.sh -
+  | bash tools/run-qwen-codex-flow.sh -
 echo "Fix the failing test in MetadataSyncService and keep the scope minimal." \
-  | bash /Users/alexorlik/repo/codepilot1c-oss/tools/run-claude-codex-flow.sh -
+  | bash tools/run-claude-codex-flow.sh -
 ```
 
 Скрипт:
@@ -129,20 +129,20 @@ echo "Fix the failing test in MetadataSyncService and keep the scope minimal." \
 Если нужно гонять не одну, а пачку простых задач, используйте queue runner:
 
 ```bash
-bash /Users/alexorlik/repo/codepilot1c-oss/tools/run-qwen-codex-queue.sh
-bash /Users/alexorlik/repo/codepilot1c-oss/tools/run-claude-codex-queue.sh
+bash tools/run-qwen-codex-queue.sh
+bash tools/run-claude-codex-queue.sh
 ```
 
 По умолчанию queue root:
 
 ```text
-/Users/alexorlik/repo/codepilot1c-oss/.runs/qwen-codex-queue/queue/
+.runs/qwen-codex-queue/queue/
 ```
 
 Для Claude-wrapper queue root по умолчанию:
 
 ```text
-/Users/alexorlik/repo/codepilot1c-oss/.runs/claude-codex-queue/queue/
+.runs/claude-codex-queue/queue/
 ```
 
 Структура очереди:
@@ -176,7 +176,7 @@ Runner обрабатывает `todo/*.md` в лексикографическ�
 Versioned каталог шаблонов лежит в:
 
 ```text
-/Users/alexorlik/repo/codepilot1c-oss/tasks/qwen-codex-queue/
+tasks/qwen-codex-queue/
 ```
 
 Шаблоны:
@@ -189,8 +189,8 @@ Versioned каталог шаблонов лежит в:
 Быстро создать task в queue `todo/` можно так:
 
 ```bash
-bash /Users/alexorlik/repo/codepilot1c-oss/tools/new-qwen-codex-task.sh --list
-bash /Users/alexorlik/repo/codepilot1c-oss/tools/new-qwen-codex-task.sh bugfix-minimal "fix metadata sync null guard"
+bash tools/new-qwen-codex-task.sh --list
+bash tools/new-qwen-codex-task.sh bugfix-minimal "fix metadata sync null guard"
 ```
 
 Скрипт положит новый markdown-файл в `.runs/qwen-codex-queue/queue/todo/` с очередным числовым префиксом.
@@ -211,7 +211,7 @@ bash /Users/alexorlik/repo/codepilot1c-oss/tools/new-qwen-codex-task.sh bugfix-m
 Versioned prompt для automation лежит в:
 
 ```text
-/Users/alexorlik/repo/codepilot1c-oss/tasks/qwen-codex-queue/automation/codex-app-queue-run.prompt.md
+tasks/qwen-codex-queue/automation/codex-app-queue-run.prompt.md
 ```
 
 Он предназначен для периодического запуска очереди через Codex app внутри этого проекта.
@@ -221,16 +221,16 @@ Versioned prompt для automation лежит в:
 Если source of truth лежит в planning bundle, например:
 
 ```text
-/Users/alexorlik/repo/codepilot1c-oss/.planning/local/qwen-runtime-surface
+.planning/local/qwen-runtime-surface
 ```
 
 используйте:
 
 ```bash
-bash /Users/alexorlik/repo/codepilot1c-oss/tools/run-qwen-codex-plan.sh \
-  /Users/alexorlik/repo/codepilot1c-oss/.planning/local/qwen-runtime-surface
-bash /Users/alexorlik/repo/codepilot1c-oss/tools/run-claude-codex-plan.sh \
-  /Users/alexorlik/repo/codepilot1c-oss/.planning/local/qwen-runtime-surface
+bash tools/run-qwen-codex-plan.sh \
+  .planning/local/qwen-runtime-surface
+bash tools/run-claude-codex-plan.sh \
+  .planning/local/qwen-runtime-surface
 ```
 
 Этот runner:
@@ -246,7 +246,7 @@ bash /Users/alexorlik/repo/codepilot1c-oss/tools/run-claude-codex-plan.sh \
 Готовый prompt для Codex app automation под background plan-run лежит в:
 
 ```text
-/Users/alexorlik/repo/codepilot1c-oss/tasks/qwen-codex-queue/automation/codex-app-plan-run.prompt.md
+tasks/qwen-codex-queue/automation/codex-app-plan-run.prompt.md
 ```
 
 Полезные env:
@@ -261,13 +261,13 @@ bash /Users/alexorlik/repo/codepilot1c-oss/tools/run-claude-codex-plan.sh \
 Артефакты этого режима пишутся в:
 
 ```text
-/Users/alexorlik/repo/codepilot1c-oss/.runs/qwen-codex-plan/<plan-key>/
+.runs/qwen-codex-plan/<plan-key>/
 ```
 
 Для Claude-wrapper:
 
 ```text
-/Users/alexorlik/repo/codepilot1c-oss/.runs/claude-codex-plan/<plan-key>/
+.runs/claude-codex-plan/<plan-key>/
 ```
 
 ## Публикация p2 из локальной сборки

--- a/evals/qwen/README.md
+++ b/evals/qwen/README.md
@@ -10,22 +10,22 @@
 
 ## Как использовать
 
-Каждый сценарий описан JSON-файлом в [`evals/qwen/scenarios`](/Users/alexorlik/repo/codepilot1c-oss/evals/qwen/scenarios).
+Каждый сценарий описан JSON-файлом в [`evals/qwen/scenarios`](scenarios).
 
 Базовый runner:
 
 ```bash
 QWEN_MCP_SERVER=codepilot1clocal \
-bash /Users/alexorlik/repo/codepilot1c-oss/tools/run-qwen-mcp-suite.sh \
-  --suite /Users/alexorlik/repo/codepilot1c-oss/evals/qwen/suite-greenfield-warehouse.json
+bash tools/run-qwen-mcp-suite.sh \
+  --suite evals/qwen/suite-greenfield-warehouse.json
 ```
 
 Точечный запуск одного сценария:
 
 ```bash
 QWEN_MCP_SERVER=codepilot1clocal \
-bash /Users/alexorlik/repo/codepilot1c-oss/tools/run-qwen-mcp-suite.sh \
-  --suite /Users/alexorlik/repo/codepilot1c-oss/evals/qwen/suite-typical-accounting.json \
+bash tools/run-qwen-mcp-suite.sh \
+  --suite evals/qwen/suite-typical-accounting.json \
   --scenario-id BUH-002
 ```
 
@@ -44,7 +44,7 @@ Runner:
 
 ```bash
 PROJECT_DIR=/abs/path/to/edt-project \
-bash /Users/alexorlik/repo/codepilot1c-oss/tools/run-qwen-local-edt-suite.sh
+bash tools/run-qwen-local-edt-suite.sh
 ```
 
 Этот wrapper:

--- a/tasks/qwen-codex-queue/README.md
+++ b/tasks/qwen-codex-queue/README.md
@@ -9,7 +9,7 @@ Use these templates to create small, bounded tasks that fit:
 - focused verification
 - reviewable diff
 
-Templates live in [`templates/`](/Users/alexorlik/repo/codepilot1c-oss/tasks/qwen-codex-queue/templates).
+Templates live in [`templates/`](templates).
 
 Recommended workflow:
 
@@ -17,19 +17,19 @@ Recommended workflow:
 2. Create a queue task with:
 
    ```bash
-   bash /Users/alexorlik/repo/codepilot1c-oss/tools/new-qwen-codex-task.sh <template> "<task slug>"
+   bash tools/new-qwen-codex-task.sh <template> "<task slug>"
    ```
 
 3. Edit the generated file under `.runs/qwen-codex-queue/queue/todo/`.
 4. Run the queue:
 
    ```bash
-   bash /Users/alexorlik/repo/codepilot1c-oss/tools/run-qwen-codex-queue.sh
+   bash tools/run-qwen-codex-queue.sh
    ```
 
 If a task lands in `needs_human/`, the queue runner can automatically generate one or more `review-followup` tasks back into `todo/` from the latest Codex findings.
 
 Automation prompt templates live in:
 
-- [`automation/codex-app-queue-run.prompt.md`](/Users/alexorlik/repo/codepilot1c-oss/tasks/qwen-codex-queue/automation/codex-app-queue-run.prompt.md) for direct queue sweeps
-- [`automation/codex-app-plan-run.prompt.md`](/Users/alexorlik/repo/codepilot1c-oss/tasks/qwen-codex-queue/automation/codex-app-plan-run.prompt.md) for plan-driven background runs from a planning bundle
+- [`automation/codex-app-queue-run.prompt.md`](automation/codex-app-queue-run.prompt.md) for direct queue sweeps
+- [`automation/codex-app-plan-run.prompt.md`](automation/codex-app-plan-run.prompt.md) for plan-driven background runs from a planning bundle


### PR DESCRIPTION
## Проблема

Примеры команд и markdown-ссылки в `README.md`, `evals/qwen/README.md` и `tasks/qwen-codex-queue/README.md` содержат абсолютные пути с конкретной машины (`/Users/<имя>/repo/codepilot1c-oss/...`). Команда, скопированная из README, на любой другой машине падает `no such file or directory` — и такие вопросы регулярно прилетают владельцам форков (люди принимают чужой захардкоженный путь за утечку данных).

## Фикс

- Все команды приведены к запуску от корня репозитория: `bash tools/run-...sh`. Скрипты `tools/*.sh` сами резолвят своё расположение (`ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"`), так что для самих скриптов рабочий каталог не критичен.
- Markdown-ссылки — относительные от содержащего файла; все цели существуют.
- Пути вывода (`.runs/...`, `tasks/...`, `.planning/...`) — относительные от корня репозитория.

Только документация, поведение кода не меняется.

Замечание в ту же тему (не трогал в этом PR): `bundles/com.codepilot1c.core.tests/.../OpenAiStreamingSessionTest.java` резолвит каталог fixtures тем же абсолютным путём `/Users/<имя>/repo/...` — тест зелёный только на одной машине.
