### PR TITLE
fix(edit): reject stray ======= separator line inside SEARCH/REPLACE blocks

### DIFF
--- a/bundles/com.codepilot1c.core/src/com/codepilot1c/core/edit/SearchReplaceFormat.java
+++ b/bundles/com.codepilot1c.core/src/com/codepilot1c/core/edit/SearchReplaceFormat.java
@@ -175,9 +175,39 @@ public class SearchReplaceFormat {
             if (block.getSearchText().contains("<<<<<<") || block.getSearchText().contains(">>>>>>>")) { //$NON-NLS-1$ //$NON-NLS-2$
                 errors.add(String.format("Блок %d: SEARCH текст содержит маркеры блоков", i + 1)); //$NON-NLS-1$
             }
+            if (block.getReplaceText().contains("<<<<<<") || block.getReplaceText().contains(">>>>>>>")) { //$NON-NLS-1$ //$NON-NLS-2$
+                errors.add(String.format("Блок %d: REPLACE текст содержит маркеры блоков", i + 1)); //$NON-NLS-1$
+            }
+
+            // A stray "=======" separator line inside a parsed block means the block was
+            // malformed (e.g. an extra separator): the non-greedy parser swallows everything
+            // up to the end marker, so the literal separator line would be written into the
+            // file as garbage. Reject instead of silently corrupting the target file.
+            if (containsSeparatorLine(block.getSearchText())) {
+                errors.add(String.format(
+                        "Блок %d: SEARCH текст содержит строку-разделитель '=======' - вероятно, лишний разделитель в блоке", i + 1)); //$NON-NLS-1$
+            }
+            if (containsSeparatorLine(block.getReplaceText())) {
+                errors.add(String.format(
+                        "Блок %d: REPLACE текст содержит строку-разделитель '=======' - вероятно, лишний разделитель в блоке", i + 1)); //$NON-NLS-1$
+            }
         }
 
         return errors;
+    }
+
+    /**
+     * Checks whether the content contains a line consisting solely of a
+     * {@code =======} separator (7+ equals signs, optional surrounding whitespace).
+     *
+     * @param content the block content to check
+     * @return true if a stray separator line is present
+     */
+    private static boolean containsSeparatorLine(String content) {
+        if (content == null || content.isEmpty()) {
+            return false;
+        }
+        return content.lines().anyMatch(line -> line.strip().matches("={7,}")); //$NON-NLS-1$
     }
 
     /**


### PR DESCRIPTION
**Symptom (live incident, 2026-07-15):** an edits payload with an accidental extra `=======` separator inside the REPLACE section passes parse+validate, and the literal `=======` line is written into the target .bsl module as garbage. Silently - the edit is reported as applied.

**Root cause:** `SEARCH_REPLACE_PATTERN` uses a non-greedy `(.*?)` for the replace group, so everything up to `>>>>>>> REPLACE` (including the stray separator) is swallowed into the replace text. `validate()` only checked stray block markers (`<<<<<<`, `>>>>>>>`) in the SEARCH text; `=======` was not checked at all.

**Fix:** `validate()` now rejects block markers in REPLACE text and a bare `={7,}` separator line in either text, before anything is applied - the file stays untouched and the caller gets an actionable error.

**Testing:** paired-eval old vs fixed (javac + junit, no Tycho): old code 2 failures out of 4 (garbage passed validation), fixed code 4/4. Clean blocks and `=` characters inside longer code lines are not flagged. Also verified live in EDT: a malformed block is rejected with the new message, file unchanged.