### PR TITLE
fix(yaxunit): canonical RunUnitTests=<config.json> instead of ;Filter=<string>

### DIFF
--- a/bundles/com.codepilot1c.core/src/com/codepilot1c/core/tools/workspace/DebugYaxunitTestsTool.java
+++ b/bundles/com.codepilot1c.core/src/com/codepilot1c/core/tools/workspace/DebugYaxunitTestsTool.java
@@ -152,12 +152,16 @@ public class DebugYaxunitTestsTool extends AbstractTool {
                 InfobaseReference infobase = projectResolver.resolveInfobase(projectName, workspaceRoot);
                 EdtResolvedLaunchInputs inputs = projectResolver.resolveLaunchInputs(projectName, workspaceRoot);
                 EdtResolvedLaunchContext context = contextBuilder.build(inputs);
-                File paramsFile = writeParamsFile(runDir, filters, waitForDebugger);
+                // Canonical YAxUnit launch: /C "RunUnitTests=<config.json>" (+Debug flags).
+                // Filter goes into the config as an OBJECT ({modules:[...]}); the previous
+                // ";Filter=<string>" crashed test loading (see RunYaxunitTestsTool). The config
+                // is not a VAParams file, so the Vanessa slot of the command builder stays empty.
+                File paramsFile = writeParamsFile(runDir, filters);
 
                 RuntimeExecutionCommandBuilder commandBuilder = runtimeService.buildTestManagerCommand(
                         projectName,
                         null,
-                        paramsFile,
+                        null,
                         workspaceRoot,
                         true,
                         true,
@@ -165,7 +169,7 @@ public class DebugYaxunitTestsTool extends AbstractTool {
                         logFile,
                         context.runtimeVersion(),
                         context.accessSettings());
-                commandBuilder.startupOption(buildStartupOption(filters, waitForDebugger));
+                commandBuilder.startupOption(buildStartupOption(paramsFile, waitForDebugger));
 
                 ProcessBuilder processBuilder = commandBuilder.toProcessBuilder();
                 processBuilder.directory(workspaceRoot);
@@ -243,26 +247,27 @@ public class DebugYaxunitTestsTool extends AbstractTool {
         return ToolResult.failure(pretty(result));
     }
 
-    private static File writeParamsFile(File runDir, String filters, boolean waitForDebugger) throws IOException {
-        JsonObject params = new JsonObject();
-        params.addProperty("command", "RunUnitTests"); //$NON-NLS-1$ //$NON-NLS-2$
-        params.addProperty("debug", true); //$NON-NLS-1$
-        params.addProperty("wait_for_debugger", waitForDebugger); //$NON-NLS-1$
+    /**
+     * Writes a canonical YAxUnit configuration file for the debug launch. The {@code filter}
+     * key must be an object with a {@code modules} array — a raw string crashes test loading
+     * (see {@link RunYaxunitTestsTool#buildFilterObject}).
+     */
+    private static File writeParamsFile(File runDir, String filters) throws IOException {
+        JsonObject config = new JsonObject();
         if (filters != null && !filters.isBlank()) {
-            params.addProperty("filter", filters); //$NON-NLS-1$
+            config.add("filter", RunYaxunitTestsTool.buildFilterObject(filters)); //$NON-NLS-1$
         }
-        File paramsFile = new File(runDir, "yaxunit-debug-params.json"); //$NON-NLS-1$
-        Files.writeString(paramsFile.toPath(), pretty(params), StandardCharsets.UTF_8);
+        config.addProperty("closeAfterTests", false); //$NON-NLS-1$
+        File paramsFile = new File(runDir, "yaxunit-debug-config.json"); //$NON-NLS-1$
+        Files.writeString(paramsFile.toPath(), pretty(config), StandardCharsets.UTF_8);
         return paramsFile;
     }
 
-    private static String buildStartupOption(String filters, boolean waitForDebugger) {
-        StringBuilder option = new StringBuilder("RunUnitTests;Debug"); //$NON-NLS-1$
+    private static String buildStartupOption(File configFile, boolean waitForDebugger) {
+        StringBuilder option = new StringBuilder("RunUnitTests=").append(configFile.getAbsolutePath()); //$NON-NLS-1$
+        option.append(";Debug"); //$NON-NLS-1$
         if (waitForDebugger) {
             option.append(";WaitForDebugger"); //$NON-NLS-1$
-        }
-        if (filters != null && !filters.isBlank()) {
-            option.append(";Filter=").append(filters.trim()); //$NON-NLS-1$
         }
         return option.toString();
     }

--- a/bundles/com.codepilot1c.core/src/com/codepilot1c/core/tools/workspace/RunYaxunitTestsTool.java
+++ b/bundles/com.codepilot1c.core/src/com/codepilot1c/core/tools/workspace/RunYaxunitTestsTool.java
@@ -162,17 +162,23 @@ public class RunYaxunitTestsTool extends AbstractTool {
                     }
                 }
 
-                File paramsFile = writeParamsFile(runDir, filters, junitXmlFile, false);
+                // Canonical YAxUnit launch: /C "RunUnitTests=<config.json>". The config carries
+                // report path/format and the filter OBJECT ({modules:[...]}); the previous
+                // ";Filter=<string>" startup parameter was merged into the launch parameters as a
+                // plain string and crashed test loading inside ЮТФильтрацияСлужебный
+                // ("Значение не является значением объектного типа"). The config file is NOT a
+                // VAParams file, so nothing is passed to the Vanessa slot of the command builder.
+                File paramsFile = writeParamsFile(runDir, filters, junitXmlFile);
                 RuntimeExecutionCommandBuilder commandBuilder = runtimeService.buildTestManagerCommand(
                         projectName,
                         null,
-                        paramsFile,
+                        null,
                         workspaceRoot,
                         false,
                         true,
                         false,
                         logFile);
-                commandBuilder.startupOption(buildStartupOption(junitXmlFile, filters, false));
+                commandBuilder.startupOption(buildStartupOption(paramsFile));
 
                 ProcessBuilder processBuilder = commandBuilder.toProcessBuilder();
                 processBuilder.directory(workspaceRoot);
@@ -259,32 +265,45 @@ public class RunYaxunitTestsTool extends AbstractTool {
         return ToolResult.failure(pretty(result));
     }
 
-    private static File writeParamsFile(File runDir, String filters, File junitXmlFile, boolean debug)
+    /**
+     * Writes a canonical YAxUnit configuration file (the payload of
+     * {@code /C "RunUnitTests=<path>"}). Keys follow the documented YAxUnit config format:
+     * {@code filter} is an object with {@code modules} array (a raw comma-separated string
+     * crashes ЮТФильтрацияСлужебный), report is described by {@code reportFormat}/{@code reportPath}.
+     */
+    private static File writeParamsFile(File runDir, String filters, File junitXmlFile)
             throws IOException {
-        JsonObject params = new JsonObject();
-        params.addProperty("command", "RunUnitTests"); //$NON-NLS-1$ //$NON-NLS-2$
-        params.addProperty("output_file", junitXmlFile.getAbsolutePath()); //$NON-NLS-1$
-        params.addProperty("junit_xml_path", junitXmlFile.getAbsolutePath()); //$NON-NLS-1$
-        params.addProperty("debug", debug); //$NON-NLS-1$
+        JsonObject config = new JsonObject();
         if (filters != null && !filters.isBlank()) {
-            params.addProperty("filter", filters); //$NON-NLS-1$
+            config.add("filter", buildFilterObject(filters)); //$NON-NLS-1$
         }
-        File paramsFile = new File(runDir, "yaxunit-params.json"); //$NON-NLS-1$
-        Files.writeString(paramsFile.toPath(), pretty(params), StandardCharsets.UTF_8);
+        config.addProperty("reportFormat", "jUnit"); //$NON-NLS-1$ //$NON-NLS-2$
+        config.addProperty("reportPath", junitXmlFile.getAbsolutePath()); //$NON-NLS-1$
+        config.addProperty("closeAfterTests", true); //$NON-NLS-1$
+        config.addProperty("showReport", false); //$NON-NLS-1$
+        File paramsFile = new File(runDir, "yaxunit-config.json"); //$NON-NLS-1$
+        Files.writeString(paramsFile.toPath(), pretty(config), StandardCharsets.UTF_8);
         return paramsFile;
     }
 
-    static String buildStartupOption(File junitXmlFile, String filters, boolean debug) {
-        StringBuilder option = new StringBuilder("RunUnitTests"); //$NON-NLS-1$
-        option.append(";OutputFile=").append(junitXmlFile.getAbsolutePath()); //$NON-NLS-1$
-        option.append(";JUnitXml=").append(junitXmlFile.getAbsolutePath()); //$NON-NLS-1$
-        if (filters != null && !filters.isBlank()) {
-            option.append(";Filter=").append(filters.trim()); //$NON-NLS-1$
+    /**
+     * Builds the YAxUnit {@code filter} object from a comma-separated list of test module names.
+     */
+    static JsonObject buildFilterObject(String filters) {
+        JsonArray modules = new JsonArray();
+        for (String part : filters.split(",")) { //$NON-NLS-1$
+            String name = part.trim();
+            if (!name.isEmpty()) {
+                modules.add(name);
+            }
         }
-        if (debug) {
-            option.append(";Debug"); //$NON-NLS-1$
-        }
-        return option.toString();
+        JsonObject filter = new JsonObject();
+        filter.add("modules", modules); //$NON-NLS-1$
+        return filter;
+    }
+
+    static String buildStartupOption(File configFile) {
+        return "RunUnitTests=" + configFile.getAbsolutePath(); //$NON-NLS-1$
     }
 
     private static File resolveJunitXmlFile(File runDir, String requestedPath) {


### PR DESCRIPTION
**Symptom (live run, EDT 2025.2.3):** `run_yaxunit_tests` with `filters` crashes YAxUnit test loading:
```
ЮТФильтрацияСлужебный.Модуль(136): Расширения = ЮТКоллекции.ЗначениеСтруктуры(ПараметрыЗапускаТестов.filter, "extensions", ...)
-> Значение не является значением объектного типа (Свойство)
```

**Root cause:** the filter was passed as `;Filter=<names>` in the /C startup string. YAxUnit merges extra `;Key=Value` pairs of the startup string on top of the launch parameters (ЮТПараметрыЗапускаСлужебный.ПарсингДополнительныхПараметров/СлитьПараметры), so `filter` arrives as a plain string, while ЮТФильтрацияСлужебный expects an object `{modules:[...], tests:[...]}`. Additionally, the custom params file (`command`/`output_file`/`junit_xml_path` keys) was passed into the VAParams slot of `buildTestManagerCommand` - that is the Vanessa channel, YAxUnit never reads it, so the junit report was not produced even without filters (OutputFile/JUnitXml are not YAxUnit keys).

**Fix:** both `run_yaxunit_tests` and `debug_yaxunit_tests` now write a canonical YAxUnit config file (`filter: {modules: [...]}`, `reportFormat: jUnit`, `reportPath`, `closeAfterTests`) and pass it via `/C RunUnitTests=<path>` (the documented YAxUnit launch contract). The VAParams slot is left empty; debug flags (`;Debug;WaitForDebugger`) stay in the startup string.

**Testing:** verified live on EDT 2025.2.3 + platform 8.3.27: filtered suite (one module) runs 6/6 in ~10-12s, junit.xml produced and parsed by the tool; a broken-assert red-run was used to confirm the filter actually reaches YAxUnit.