### PR TITLE
fix: пре-резолв типов берёт из списка только первый — source подписки падает со второго

### DIFF
--- a/bundles/com.codepilot1c.core/src/com/codepilot1c/core/edt/metadata/EdtMetadataService.java
+++ b/bundles/com.codepilot1c.core/src/com/codepilot1c/core/edt/metadata/EdtMetadataService.java
@@ -7508,9 +7508,39 @@ public class EdtMetadataService {
         if (typeStrings == null || map == null || key == null || !hasMapKeyIgnoreCase(map, key)) {
             return;
         }
-        String typeStr = normalizeTypeLookupQuery(getMapValueIgnoreCase(map, key));
-        if (typeStr != null && !typeStr.isBlank()) {
-            typeStrings.add(typeStr);
+        collectTypeLookupQueries(getMapValueIgnoreCase(map, key), typeStrings);
+    }
+
+    /**
+     * Collects every type string from a value instead of only the first one.
+     * <p>
+     * {@code normalizeTypeLookupQuery} returns the first non-blank element of a list and drops the
+     * rest. That is correct for single-valued fields such as {@code type}, but multi-valued ones
+     * (notably {@code EventSubscription.source}, which holds a list of object types) then reach the
+     * pre-resolution map with only their first type. Every following type fails later with
+     * "Type not found for field 'source'", because an {@code EventSubscription} is not a
+     * {@code BasicFeature} and therefore has no {@code resolveTypeItemForFeature} fallback.
+     */
+    private void collectTypeLookupQueries(Object value, Set<String> out) {
+        if (value == null || out == null) {
+            return;
+        }
+        if (value instanceof List<?> list) {
+            for (Object item : list) {
+                collectTypeLookupQueries(item, out);
+            }
+            return;
+        }
+        if (value instanceof Map<?, ?> map) {
+            Object types = getMapValueIgnoreCase(map, "types"); //$NON-NLS-1$
+            if (types != null && types != value) {
+                collectTypeLookupQueries(types, out);
+                return;
+            }
+        }
+        String single = normalizeTypeLookupQuery(value);
+        if (single != null && !single.isBlank()) {
+            out.add(single);
         }
     }
 


### PR DESCRIPTION
## Проблема

Установка `EventSubscription.source` с несколькими объектными типами через `update_metadata`
падает на **втором** элементе:

```
[INVALID_PROPERTY_VALUE] Type not found for field 'source': <второй тип>
```

Один тип проходит всегда — из-за этого отказ выглядит как проблема написания имени типа,
а не как проблема количества.

## Причина

`addTypeStringIfPresent` наполняет карту пре-резолва через `normalizeTypeLookupQuery`,
а тот на списке возвращает первый непустой элемент и отбрасывает остальные:

```java
if (value instanceof List<?> list) {
    for (Object item : list) {
        String normalized = normalizeTypeLookupQuery(item);
        if (normalized != null) {
            return normalized;   // остаток списка теряется
        }
    }
    return null;
}
```

Для одиночных полей (`type`, `commandParameterType`) это верно, но `source` хранит список,
поэтому в `preResolvedTypes` попадает только его первый тип.

Восстановить остальные ниже по потоку нельзя: `createTypeDescription` уходит в
`resolveTypeItemForFeature` только когда цель — `BasicFeature`, а `EventSubscription` им
не является, и выполнение сразу доходит до `Type not found`.

Обхода на стороне вызывающего тоже нет: `set` заменяет список целиком, добавить типы
по одному не получится.

## Решение

Добавлен `collectTypeLookupQueries` — обходит списки и карты вида `{types: [...]}` и собирает
все элементы. Для одиночных значений поведение прежнее.

`normalizeTypeLookupQuery` намеренно не тронут: он используется как одиночный нормализатор
более чем в десяти других местах.

## Проверка

- [x] Воспроизведено бисекцией на живом EDT-воркспейсе: 1 тип проходит,
      2 / 4 / 8 отбиваются всегда на втором элементе списка.
- [x] После правки подписка с 22 объектными типами документов записывается одним вызовом,
      в итоговом `.mdo` присутствуют все 22 элемента `<types>`.
- [ ] Автотест не добавлен: окружающий код требует BM-транзакции и EDT-воркспейса,
      готового харнесса под это в модуле нет. Готов добавить, если подскажете желаемую форму.
