### PR TITLE
fix(tools): grep ищет и по EDT-дескрипторам, а не только по .bsl/.os/.java/.xml

### DIFF
--- a/bundles/com.codepilot1c.core/src/com/codepilot1c/core/tools/file/GrepTool.java
+++ b/bundles/com.codepilot1c.core/src/com/codepilot1c/core/tools/file/GrepTool.java
@@ -213,9 +213,13 @@ public class GrepTool extends AbstractTool {
 
     private boolean matchesFilePattern(String name, String pattern) {
         if (pattern == null || pattern.isEmpty()) {
-            // Default to common code files
+            // Default to common code files plus EDT descriptors. Omitting .mdo/.form made a bare
+            // grep silently skip every metadata and form descriptor in an EDT workspace and answer
+            // "0 matches" — a false negative that reads as proof of absence.
             return name.endsWith(".bsl") || name.endsWith(".os") ||  //$NON-NLS-1$ //$NON-NLS-2$
-                   name.endsWith(".java") || name.endsWith(".xml"); //$NON-NLS-1$ //$NON-NLS-2$
+                   name.endsWith(".java") || name.endsWith(".xml") || //$NON-NLS-1$ //$NON-NLS-2$
+                   name.endsWith(".mdo") || name.endsWith(".form") || //$NON-NLS-1$ //$NON-NLS-2$
+                   name.endsWith(".dcs") || name.endsWith(".dcss"); //$NON-NLS-1$ //$NON-NLS-2$
         }
         String regex = pattern
                 .replace(".", "\\.") //$NON-NLS-1$ //$NON-NLS-2$


### PR DESCRIPTION
## Проблема

Вызов `grep` без `file_pattern` не находит ничего в `.mdo` и `.form` — отвечает `Found: 0 matches`, хотя совпадения в файлах есть.

Опасно именно молчание: пустой результат читается как доказательство отсутствия. Живой случай — поиск остатков переименованного реквизита формы дал ноль, и правка была объявлена завершённой; реальные вхождения остались в `.form` и нашлись только обычным поиском по диску.

## Причина

`GrepTool.matchesFilePattern` при пустом `file_pattern` возвращает набор по умолчанию из четырёх расширений:

```java
return name.endsWith(".bsl") || name.endsWith(".os")
    || name.endsWith(".java") || name.endsWith(".xml");
```

Для EDT-проекта это мимо: метаданные лежат в `.mdo`, формы в `.form`, схемы компоновки в `.dcs`/`.dcss`. XML как класса файлов в EDT-формате нет вовсе.

## Решение

Добавлены `.mdo`, `.form`, `.dcs`, `.dcss`. Поведение при явном `file_pattern` не меняется.

## Проверка

Сборка `mvn -DskipTests package` — BUILD SUCCESS. Живьём: запрос, возвращавший `0 matches` на старой сборке, на новой находит оба вхождения в `.form`.