### PR TITLE
fix(metadata): сохранять составной тип реквизита формы при обновлении

### DIFF
--- a/bundles/com.codepilot1c.core/src/com/codepilot1c/core/edt/metadata/EdtMetadataService.java
+++ b/bundles/com.codepilot1c.core/src/com/codepilot1c/core/edt/metadata/EdtMetadataService.java
@@ -2654,6 +2654,13 @@ public class EdtMetadataService {
         return new FormAttributePatch(patch, typeValue, asListOfMaps(columnsValue));
     }
 
+    /**
+     * Applies the requested value type to a form attribute or form attribute column. The requested
+     * type may be composite: 1C allows several types on one attribute, and rebuilding a composite
+     * type from a single component silently narrows it (a data-losing update, not a missing
+     * feature). Composite input is accepted either as a list or with the pipe separator used by the
+     * platform type chooser, e.g. {@code "CatalogRef.Партнеры|String|CatalogRef.Контрагенты"}.
+     */
     private void applyFormAttributeType(
             AbstractFormAttribute attribute,
             Object typeValue,
@@ -2664,6 +2671,56 @@ public class EdtMetadataService {
         if (attribute == null || typeValue == null) {
             return;
         }
+        List<Object> requestedTypes = splitCompositeTypeValue(typeValue);
+        if (requestedTypes.isEmpty()) {
+            return;
+        }
+        TypeDescription typeDesc = McoreFactory.eINSTANCE.createTypeDescription();
+        TypeDescription existingType = extractTypeDescriptionFromEObject(attribute);
+        for (Object requestedType : requestedTypes) {
+            appendFormAttributeType(attribute, requestedType, typeDesc, existingType,
+                    transaction, preResolvedTypes, txConfiguration);
+        }
+        setTypeDescriptionOnEObject(attribute, typeDesc);
+    }
+
+    /**
+     * Splits a requested type into its components. A scalar type yields exactly one element, so the
+     * behaviour for non-composite input is unchanged.
+     */
+    private List<Object> splitCompositeTypeValue(Object typeValue) {
+        List<Object> parts = new ArrayList<>();
+        if (typeValue instanceof List<?> list) {
+            for (Object item : list) {
+                if (item != null) {
+                    parts.addAll(splitCompositeTypeValue(item));
+                }
+            }
+            return parts;
+        }
+        if (typeValue instanceof String text) {
+            for (String piece : text.split("\\|")) { //$NON-NLS-1$
+                String trimmed = piece.trim();
+                if (!trimmed.isEmpty()) {
+                    parts.add(trimmed);
+                }
+            }
+            return parts;
+        }
+        parts.add(typeValue);
+        return parts;
+    }
+
+    /** Resolves one component of a (possibly composite) type and appends it to {@code typeDesc}. */
+    private void appendFormAttributeType(
+            AbstractFormAttribute attribute,
+            Object typeValue,
+            TypeDescription typeDesc,
+            TypeDescription existingType,
+            IBmPlatformTransaction transaction,
+            Map<String, TypeItem> preResolvedTypes,
+            Configuration txConfiguration
+    ) {
         validateFormAttributeType(typeValue);
         TypeSpec typeSpec = normalizeTypeSpec(typeValue);
         String typeQuery = typeSpec.typeQuery();
@@ -2716,12 +2773,10 @@ public class EdtMetadataService {
                             + ". " + FORM_ATTRIBUTE_TYPE_RECOVERY, false); //$NON-NLS-1$
         }
 
-        TypeDescription typeDesc = McoreFactory.eINSTANCE.createTypeDescription();
         typeDesc.getTypes().add(txTypeItem);
 
         TypeItem resolvedForName = candidate != null ? candidate : txTypeItem;
         String typeName = resolveTypeNameForQualifiers(resolvedForName, typeSpec);
-        TypeDescription existingType = extractTypeDescriptionFromEObject(attribute);
         if (isNumberType(typeName)) {
             NumberQualifiers nq = McoreFactory.eINSTANCE.createNumberQualifiers();
             Integer precision = typeSpec.numberPrecision();
@@ -2755,8 +2810,6 @@ public class EdtMetadataService {
                             : DateFractions.DATE_TIME));
             typeDesc.setDateQualifiers(dq);
         }
-
-        setTypeDescriptionOnEObject(attribute, typeDesc);
     }
 
     /**


### PR DESCRIPTION
## Проблема

`update` реквизита или колонки формы с указанием `type` **молча сужает составной тип до одного**. Тул при этом рапортует успехом.

Пример: у колонки реквизита-таблицы тип из трёх составляющих (две ссылки на справочники и строка). Любое обновление с `type` оставляет ровно одну составляющую, остальные две теряются. Заметить можно только в рантайме, когда в поле попробуют записать значение отброшенного типа.

Это потеря данных, а не отсутствие фичи: пользователь не просил менять состав типа.

## Причина

`applyFormAttributeType` собирает описание типа ровно из одного элемента и подменяет им существующее:

```java
TypeDescription typeDesc = McoreFactory.eINSTANCE.createTypeDescription();
typeDesc.getTypes().add(txTypeItem);
...
setTypeDescriptionOnEObject(attribute, typeDesc);
```

## Решение

Составной тип принимается списком либо строкой с разделителем `|` (как в платформенном выборе типа):

```
"CatalogRef.Партнеры|String(0)|CatalogRef.Контрагенты"
```

Каждая составляющая резолвится прежним конвейером (pre-resolved → namespace → external → simple → `TypeProviderService`), все складываются в одно `TypeDescription`. Квалификаторы строки, числа и даты применяет та составляющая, к которой они относятся.

Для скалярного входа путь исполнения прежний: `splitCompositeTypeValue` возвращает один элемент, поведение не меняется.

## Связь с #75

Дополняет #75: там чинится поиск типов списка в карте пре-резолва (`addTypeStringIfPresent` / `normalizeTypeLookupQuery`), здесь — их применение к реквизиту. Функции разные, изменения независимы.

## Проверка

Сборка — BUILD SUCCESS. Живьём: колонка с составным типом из трёх составляющих после обновления сохраняет все три; на старой сборке оставалась одна.