### PR TITLE
fix(metadata): наследовать Managed-режим блокировок при создании и применять indexing/fullTextSearch к измерениям регистров

### DIFF
--- a/bundles/com.codepilot1c.core/src/com/codepilot1c/core/edt/metadata/EdtMetadataService.java
+++ b/bundles/com.codepilot1c.core/src/com/codepilot1c/core/edt/metadata/EdtMetadataService.java
@@ -120,6 +120,7 @@ import com._1c.g5.v8.dt.metadata.mdclass.BasicForm;
 import com._1c.g5.v8.dt.metadata.mdclass.BasicTemplate;
 import com._1c.g5.v8.dt.metadata.mdclass.Configuration;
 import com._1c.g5.v8.dt.metadata.mdclass.DataProcessor;
+import com._1c.g5.v8.dt.metadata.mdclass.DefaultDataLockControlMode;
 import com._1c.g5.v8.dt.metadata.mdclass.Document;
 import com._1c.g5.v8.dt.metadata.mdclass.FormType;
 import com._1c.g5.v8.dt.metadata.mdclass.TemplateType;
@@ -347,7 +348,7 @@ public class EdtMetadataService {
                     txConfiguration,
                     txObject,
                     request.kind(),
-                    request.properties(),
+                    withConfigurationLockModeDefault(txConfiguration, txObject, request.properties()),
                     transaction,
                     capturedTopLevelPropertyTypes,
                     platformVersion,
@@ -6758,21 +6759,20 @@ public class EdtMetadataService {
     }
 
     private void applyFullTextSearch(BasicFeature feature, Map<String, Object> properties) {
-        if (!(feature instanceof com._1c.g5.v8.dt.metadata.mdclass.DbObjectAttribute dbo)) {
-            if (firstNonNull(
-                    getMapValueIgnoreCase(properties, "fullTextSearch"), //$NON-NLS-1$
-                    getMapValueIgnoreCase(properties, "full_text_search"), //$NON-NLS-1$
-                    getMapValueIgnoreCase(properties, "fulltextsearch")) != null) { //$NON-NLS-1$
-                LOG.warn("applyBasicFeatureCreateProperties: fullTextSearch not applicable for %s", //$NON-NLS-1$
-                        feature.eClass().getName());
-            }
-            return;
-        }
         Object raw = firstNonNull(
                 getMapValueIgnoreCase(properties, "fullTextSearch"), //$NON-NLS-1$
                 getMapValueIgnoreCase(properties, "full_text_search"), //$NON-NLS-1$
                 getMapValueIgnoreCase(properties, "fulltextsearch")); //$NON-NLS-1$
         if (raw == null) {
+            return;
+        }
+        // Same rationale as applyIndexing: register dimensions/resources/attributes carry
+        // their own fullTextSearch feature outside the DbObjectAttribute hierarchy.
+        EStructuralFeature ftsFeature =
+                feature.eClass().getEStructuralFeature("fullTextSearch"); //$NON-NLS-1$
+        if (!(ftsFeature instanceof EAttribute ftsAttribute)) {
+            LOG.warn("applyBasicFeatureCreateProperties: fullTextSearch not applicable for %s", //$NON-NLS-1$
+                    feature.eClass().getName());
             return;
         }
         String literal = BasicFeaturePropertyAliases.resolveFullTextSearch(String.valueOf(raw)).orElse(null);
@@ -6781,7 +6781,7 @@ public class EdtMetadataService {
             return;
         }
         try {
-            dbo.setFullTextSearch(
+            feature.eSet(ftsAttribute,
                     com._1c.g5.v8.dt.metadata.mdclass.FullTextSearchUsing.valueOf(literal));
         } catch (Exception e) {
             LOG.warn("applyBasicFeatureCreateProperties: failed to apply fullTextSearch=%s: %s", literal, e.getMessage()); //$NON-NLS-1$
@@ -6789,15 +6789,19 @@ public class EdtMetadataService {
     }
 
     private void applyIndexing(BasicFeature feature, Map<String, Object> properties) {
-        if (!(feature instanceof com._1c.g5.v8.dt.metadata.mdclass.DbObjectAttribute dbo)) {
-            if (getMapValueIgnoreCase(properties, "indexing") != null) { //$NON-NLS-1$
-                LOG.warn("applyBasicFeatureCreateProperties: indexing not applicable for %s", //$NON-NLS-1$
-                        feature.eClass().getName());
-            }
-            return;
-        }
         Object raw = getMapValueIgnoreCase(properties, "indexing"); //$NON-NLS-1$
         if (raw == null) {
+            return;
+        }
+        // Resolve the EMF feature instead of instanceof DbObjectAttribute: register
+        // dimensions/resources/attributes declare their own indexing pair outside the
+        // DbObjectAttribute hierarchy (RegisterDimension.setIndexing etc.), and the old
+        // guard silently dropped indexing for them (warn in a log nobody reads).
+        EStructuralFeature indexingFeature =
+                feature.eClass().getEStructuralFeature("indexing"); //$NON-NLS-1$
+        if (!(indexingFeature instanceof EAttribute indexingAttribute)) {
+            LOG.warn("applyBasicFeatureCreateProperties: indexing not applicable for %s", //$NON-NLS-1$
+                    feature.eClass().getName());
             return;
         }
         String literal = BasicFeaturePropertyAliases.resolveIndexing(String.valueOf(raw)).orElse(null);
@@ -6806,7 +6810,7 @@ public class EdtMetadataService {
             return;
         }
         try {
-            dbo.setIndexing(
+            feature.eSet(indexingAttribute,
                     com._1c.g5.v8.dt.metadata.mdclass.Indexing.valueOf(literal));
         } catch (Exception e) {
             LOG.warn("applyBasicFeatureCreateProperties: failed to apply indexing=%s: %s", literal, e.getMessage()); //$NON-NLS-1$
@@ -10238,6 +10242,36 @@ public class EdtMetadataService {
             }
         }
         return Collections.unmodifiableSet(result);
+    }
+
+    /**
+     * Mirrors the EDT UI behaviour for new lockable objects: in a configuration whose data lock
+     * control mode is Managed, a freshly created register/catalog/document/etc. must be Managed
+     * too, while the raw EMF default is Automatic — a silent mismatch that surfaces later as an
+     * АПК/audit finding. An explicit {@code dataLockControlMode} from the caller always wins.
+     * Non-Managed configurations are left untouched: Automatic matches the EMF default, and
+     * AutomaticAndManaged has no single right answer for a new object.
+     */
+    private Map<String, Object> withConfigurationLockModeDefault(
+            Configuration configuration, MdObject target, Map<String, Object> properties) {
+        if (configuration == null || target == null) {
+            return properties;
+        }
+        if (configuration.getDataLockControlMode() != DefaultDataLockControlMode.MANAGED) {
+            return properties;
+        }
+        if (target.eClass().getEStructuralFeature("dataLockControlMode") == null) { //$NON-NLS-1$
+            return properties;
+        }
+        if (properties != null && hasMapKeyIgnoreCase(properties, "dataLockControlMode")) { //$NON-NLS-1$
+            return properties;
+        }
+        Map<String, Object> merged = new LinkedHashMap<>();
+        merged.put("dataLockControlMode", "Managed"); //$NON-NLS-1$ //$NON-NLS-2$
+        if (properties != null) {
+            merged.putAll(properties);
+        }
+        return merged;
     }
 
     private MdObject createTopLevelObject(MetadataKind kind) {


### PR DESCRIPTION
## Что чинит

Два дефекта create-пути `EdtMetadataService`, оба воспроизведены живой работой агента над конфигурацией с управляемым режимом блокировок:

1. **`create_metadata` не наследует режим блокировок конфигурации.** Новый регистр/справочник/документ получает голый EMF-дефолт `dataLockControlMode=Automatic`, хотя конфигурация в режиме «Управляемый» и EDT UI в той же ситуации создаёт объект с `Managed`. Рассинхрон молчаливый — всплывает позже замечанием АПК/аудита.
2. **`indexing` / `fullTextSearch` молча теряются на измерениях, ресурсах и реквизитах регистров.** `applyIndexing`/`applyFullTextSearch` гвардят на `instanceof DbObjectAttribute`, но регистровые виды объявляют собственные пары сеттеров вне этой иерархии (`RegisterDimension.setIndexing` и т.д., сверено по mdclass EDT 2025.2.3). Переданное значение уходило в warn-лог, объект создавался с `DontIndex`.

## Как

- `withConfigurationLockModeDefault(...)`: если конфигурация в `Managed`, у создаваемого вида есть фича `dataLockControlMode` и вызывающий её не передал — в properties подставляется `Managed`. Дефолт едет через штатный `applyTopLevelProperties`: конвертация значений и applied-лог общие. Явно переданное значение всегда побеждает; конфигурации `Automatic`/`AutomaticAndManaged` не затрагиваются (у первой дефолт и так совпадает, у второй однозначного ответа нет).
- `applyIndexing`/`applyFullTextSearch`: вместо `instanceof DbObjectAttribute` — резолв EMF-фичи на `eClass()`; одна ветка кроет и DbObjectAttribute, и все регистровые виды. Отсутствие фичи у вида по-прежнему даёт warn, поведение для прочих видов не меняется.

Тот же принцип, что уже принят для `usePurposes` новых форм и геометрии HTML-поля: инструмент должен давать то, что разработчик получает в EDT UI.

## Проверка

- Ветка собирается Tycho (`mvn -DskipTests package`, модуль tests исключён — он в репозитории сейчас не компилируется независимо от этой правки).
- Живая верификация против EDT 2025.2.3: `create_metadata` InformationRegister без `dataLockControlMode` в properties → в `.mdo` появляется `<dataLockControlMode>Managed</dataLockControlMode>`; `add_metadata_child` Dimension батчем с `indexing: "Index"` → `<indexing>Index</indexing>`. До правки: `Automatic` и `DontIndex` соответственно.
- Юнит-тестов на `EdtMetadataService` в репозитории нет; если подскажете предпочтительное место — дополню.
