### PR TITLE
fix(forms,metadata): set_command, корень конфигурации в update_metadata, чтение подсказок в inspect_form_layout

### DIFF
--- a/bundles/com.codepilot1c.core/src/com/codepilot1c/core/edt/metadata/EdtMetadataService.java
+++ b/bundles/com.codepilot1c.core/src/com/codepilot1c/core/edt/metadata/EdtMetadataService.java
@@ -1136,6 +1136,23 @@ public class EdtMetadataService {
                     }
                     summaries.add("set_item[" + operationIndex + "]: id=" + item.getId()); //$NON-NLS-1$ //$NON-NLS-2$
                 }
+                case "setcommand", "setformcommand", "setcommandprops" -> {
+                    // Form commands live in formModel.getFormCommands(), NOT in the item
+                    // tree, so set_item could never reach them: it failed with
+                    // "Form item not found". Their titles and tooltips were therefore
+                    // unreachable through MCP, and a caller had to edit Form.form by hand
+                    // — exactly what the tool exists to prevent.
+                    FormCommand command = resolveRequiredFormCommand(formModel, operation);
+                    Map<String, Object> set = extractOperationSet(operation);
+                    if (set.isEmpty()) {
+                        throw new MetadataOperationException(
+                                MetadataOperationCode.INVALID_METADATA_CHANGE,
+                                "set_command operation requires non-empty 'set' or 'properties' map", false); //$NON-NLS-1$
+                    }
+                    applyFormPropertySet(command, set);
+                    summaries.add("set_command[" + operationIndex + "]: name=" //$NON-NLS-1$ //$NON-NLS-2$
+                            + command.getName());
+                }
                 case "removeitem", "deleteitem" -> {
                     FormItem item = resolveRequiredItem(formModel, operation);
                     FormItemContainer parent = findParentContainer(formModel, item);
@@ -2116,6 +2133,36 @@ public class EdtMetadataService {
                     "Form item not found: id=" + itemId + ", name=" + itemName, false); //$NON-NLS-1$ //$NON-NLS-2$
         }
         return item;
+    }
+
+    private FormCommand resolveRequiredFormCommand(Form formModel, Map<String, Object> operation) {
+        String name = asString(getMapValueIgnoreCase(operation, "command_name")); //$NON-NLS-1$
+        if (name == null) {
+            name = asString(getMapValueIgnoreCase(operation, "item_name")); //$NON-NLS-1$
+        }
+        if (name == null) {
+            name = asString(getMapValueIgnoreCase(operation, "name")); //$NON-NLS-1$
+        }
+        Integer id = asOptionalInteger(getMapValueIgnoreCase(operation, "command_id"), "command_id"); //$NON-NLS-1$ //$NON-NLS-2$
+        if (name == null && id == null) {
+            throw new MetadataOperationException(
+                    MetadataOperationCode.INVALID_METADATA_CHANGE,
+                    "Operation requires command_name or command_id", false); //$NON-NLS-1$
+        }
+        for (FormCommand command : formModel.getFormCommands()) {
+            if (command == null) {
+                continue;
+            }
+            if (id != null && command.getId() == id.intValue()) {
+                return command;
+            }
+            if (name != null && name.equalsIgnoreCase(command.getName())) {
+                return command;
+            }
+        }
+        throw new MetadataOperationException(
+                MetadataOperationCode.METADATA_NOT_FOUND,
+                "Form command not found: id=" + id + ", name=" + name, false); //$NON-NLS-1$ //$NON-NLS-2$
     }
 
     private FormItem findFormItem(FormItemContainer container, Integer id, String name) {
@@ -3504,11 +3551,19 @@ public class EdtMetadataService {
             if (feature == null || feature.isDerived() || feature.isTransient() || feature.isVolatile()) {
                 continue;
             }
-            if (!includeTitles && "title".equalsIgnoreCase(feature.getName())) { //$NON-NLS-1$
+            if (!includeTitles && ("title".equalsIgnoreCase(feature.getName()) //$NON-NLS-1$
+                    || "toolTip".equalsIgnoreCase(feature.getName()))) { //$NON-NLS-1$
                 continue;
             }
             if (feature instanceof EReference reference && reference.isContainment()) {
-                continue;
+                // Localized strings (toolTip and friends) are containment EMaps, so the
+                // blanket containment skip hid them completely: inspect_form_layout
+                // returned toolTipRepresentation but never the tooltip text itself, and
+                // a caller had no way to read the current value before changing it.
+                // EMap values are already flattened by simplifyFeatureValue below.
+                if (!(object.eGet(feature) instanceof EMap<?, ?>)) {
+                    continue;
+                }
             }
             Object value = object.eGet(feature);
             if (value == null) {
@@ -6017,6 +6072,13 @@ public class EdtMetadataService {
     private MdObject resolveByFqn(Configuration configuration, String fqn) {
         LOG.debug("resolveByFqn: %s", fqn); //$NON-NLS-1$
         String[] parts = fqn != null ? fqn.split("\\.") : new String[0]; //$NON-NLS-1$
+        // The configuration root carries no <Type>.<Name> pair, so the generic parser
+        // rejected it outright and root properties (command interface order, vendor,
+        // version, compatibility mode) stayed unreachable through update_metadata —
+        // the only remaining route was editing Configuration.mdo by hand.
+        if (parts.length == 1 && isConfigurationRootFqn(parts[0])) {
+            return configuration;
+        }
         if (parts.length < 2) {
             throw new MetadataOperationException(
                     MetadataOperationCode.METADATA_PARENT_NOT_FOUND,
@@ -9930,12 +9992,23 @@ public class EdtMetadataService {
 
     private String extractTopLevelFqn(String fqn) {
         String[] parts = fqn != null ? fqn.split("\\.") : new String[0]; //$NON-NLS-1$
+        // The configuration root IS its own top-level object: it has no owner to
+        // export instead of it. Without this branch a successful root mutation still
+        // failed afterwards, on the export step, with "Invalid metadata FQN".
+        if (parts.length == 1 && isConfigurationRootFqn(parts[0])) {
+            return parts[0];
+        }
         if (parts.length < 2) {
             throw new MetadataOperationException(
                     MetadataOperationCode.METADATA_NOT_FOUND,
                     "Invalid metadata FQN: " + fqn, false); //$NON-NLS-1$
         }
         return parts[0] + "." + parts[1]; //$NON-NLS-1$
+    }
+
+    private boolean isConfigurationRootFqn(String candidate) {
+        return "Configuration".equalsIgnoreCase(candidate) //$NON-NLS-1$
+                || "Конфигурация".equalsIgnoreCase(candidate); //$NON-NLS-1$
     }
 
     @SuppressWarnings("unchecked")

--- a/bundles/com.codepilot1c.core/src/com/codepilot1c/core/tools/forms/MutateFormModelTool.java
+++ b/bundles/com.codepilot1c.core/src/com/codepilot1c/core/tools/forms/MutateFormModelTool.java
@@ -47,7 +47,7 @@ public class MutateFormModelTool extends AbstractTool {
                     "properties": {
                       "op": {
                         "type": "string",
-                        "enum": ["set_form_props", "add_group", "add_field", "add_table", "add_command", "add_button", "set_item", "remove_item", "move_item", "add_event_handler", "set_event_handler", "remove_event_handler"],
+                        "enum": ["set_form_props", "add_group", "add_field", "add_table", "add_command", "add_button", "set_item", "set_command", "remove_item", "move_item", "add_event_handler", "set_event_handler", "remove_event_handler"],
                         "description": "Visual form operation. add_field creates a simple UI field; add_table creates a Table item and, with data_path to a ValueTable/ValueTree/tabular attribute, auto-generates its columns. Neither creates the form attribute — create attributes with apply_form_recipe first."
                       },
                       "data_path": {


### PR DESCRIPTION
Три случая, когда `codepilot` не мог выполнить правку и приходилось руками открывать файлы EDT-проекта. Все вскрыты на живой задаче — приведение конфигурации к стандарту подсказок (std478) в проекте, который готовится к «1С:Совместимо».

### 1. Команды формы недостижимы для `mutate_form_model`

Команды лежат в `Form.getFormCommands()`, а `set_item` ищет только по дереву `getItems()`, поэтому правка свойств команды падала:

```
[METADATA_NOT_FOUND] Form item not found: id=null, name=ОК
```

В нашей конфигурации 55 подсказок сидели именно на командах. Добавлена операция `set_command` (`command_name` | `command_id` + `set`).

### 2. `update_metadata` не принимает корневой `Configuration`

`resolveByFqn` требует пару `<Type>.<Name>`:

```
[METADATA_PARENT_NOT_FOUND] Parent FQN must be <Type>.<Name>[.<Marker>.<Name>...]
```

Под замком оказались все корневые свойства — в том числе порядок разделов командного интерфейса, а это прямое требование сертификации (раздел администрирования должен быть последним).

Отдельная тонкость: после правки одного лишь `resolveByFqn` мутация проходит, но операция падает **уже после неё** — на шаге экспорта, в `extractTopLevelFqn`, с `Invalid metadata FQN: Configuration`. Поэтому корень распознаётся в обоих местах, через общий предикат.

### 3. `inspect_form_layout` не возвращает подсказки

`collectScalarProperties` отсекает все containment-ссылки, а `toolTip` — containment-EMap. В ответе оставался только `toolTipRepresentation`, самого текста не было: прочитать текущее значение перед изменением нечем. Теперь локализованные EMap-строки не отсекаются и отдаются вместе с `title`, под тем же флагом `include_titles`.

### Проверка

Собрано на текущем `main` и проверено на живой конфигурации (52 формы нашего слоя):

- снято 113 избыточных подсказок — 59 у элементов и 54 у команд, которые до этого были недоступны в принципе;
- переставлен порядок разделов командного интерфейса через `update_metadata`;
- подсказки читаются через `inspect_form_layout`;
- регресс проекта на YAxUnit — 474/474 зелёный.

Правки затрагивают два файла и не меняют поведение существующих операций.