### PR TITLE
feat(diagnostics): query_event_log — чтение журнала регистрации файловой ИБ из MCP

### DIFF
--- a/bundles/com.codepilot1c.core.tests/src/com/codepilot1c/core/edt/observability/eventlog/EventLogServiceSinceWindowTest.java
+++ b/bundles/com.codepilot1c.core.tests/src/com/codepilot1c/core/edt/observability/eventlog/EventLogServiceSinceWindowTest.java
@@ -1,0 +1,93 @@
+package com.codepilot1c.core.edt.observability.eventlog;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Set;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * A partition far larger than the scan cap must still answer a since-bounded
+ * query: the walk seeks to the window instead of parsing the partition from
+ * byte zero.
+ *
+ * <p>Without the seek the cap is spent on records older than the window and the
+ * query returns an empty list — indistinguishable from a genuinely quiet window,
+ * which is the worst failure mode for a log query used as a CI gate.</p>
+ */
+public class EventLogServiceSinceWindowTest {
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    private static final int SCAN_CAP = 200;
+    private static final int OLD_RECORDS = 5_000;
+
+    @Test
+    public void findsTailRecordBehindTheScanCap() throws IOException {
+        Path logDir = writeLog();
+        EventLogService.Query q = new EventLogService.Query();
+        q.sinceRaw = 20260818_200000L;
+        q.severities = Set.of("Error"); //$NON-NLS-1$
+        q.limit = 10;
+
+        EventLogService.Result result = new EventLogService(SCAN_CAP).query(logDir, q);
+
+        assertEquals("the record inside the window must be found", 1, result.records.size()); //$NON-NLS-1$
+        assertFalse("the window is small, the cap must not be hit", result.scanCapHit); //$NON-NLS-1$
+        assertTrue("records older than the window must not be parsed", //$NON-NLS-1$
+                result.scanned < OLD_RECORDS);
+    }
+
+    /** Records before the window must stay invisible even though they are parsed cheaply. */
+    @Test
+    public void ignoresRecordsBeforeTheWindow() throws IOException {
+        Path logDir = writeLog();
+        EventLogService.Query q = new EventLogService.Query();
+        q.sinceRaw = 20260818_235959L; // after every record in the file
+        q.limit = 10;
+
+        EventLogService.Result result = new EventLogService(SCAN_CAP).query(logDir, q);
+
+        assertEquals("nothing is in that window", 0, result.records.size()); //$NON-NLS-1$
+    }
+
+    /**
+     * Builds one daily partition: many records before the window and a single
+     * Error inside it. The reference catalog is minimal — decoding details are
+     * covered elsewhere, here only the seek matters.
+     */
+    private Path writeLog() throws IOException {
+        Path logDir = folder.newFolder("1Cv8Log").toPath(); //$NON-NLS-1$
+        Files.writeString(logDir.resolve("1Cv8.lgf"), //$NON-NLS-1$
+                "1CV8LOG(ver 2.0)\n{1,\n{1,0,\"Data\"}\n},\n", StandardCharsets.UTF_8); //$NON-NLS-1$
+
+        StringBuilder sb = new StringBuilder("1CV8LOG(ver 2.0)\n") //$NON-NLS-1$
+                .append("67aed8c3-5c53-46a2-8772-f76e1dacbba1\n\n"); //$NON-NLS-1$
+        for (int i = 0; i < OLD_RECORDS; i++) {
+            sb.append(record("20260818010101", "I")); //$NON-NLS-1$ //$NON-NLS-2$
+        }
+        sb.append(record("20260818203000", "E")); //$NON-NLS-1$ //$NON-NLS-2$
+
+        Files.writeString(logDir.resolve("20260818000000.lgp"), sb.toString(), //$NON-NLS-1$
+                StandardCharsets.UTF_8);
+        return logDir;
+    }
+
+    /** Severity code sits at top-level index 8, mirroring a real {@code .lgp} record. */
+    private static String record(String stamp, String severity) {
+        return "{" + stamp + ",N,\n" //$NON-NLS-1$ //$NON-NLS-2$
+                + "{0,0},1,1,1,1,1," + severity + ",\"\",0,\n" //$NON-NLS-1$ //$NON-NLS-2$
+                + "{\"U\"},\"\",0,0,0,1,0,\n" //$NON-NLS-1$
+                + "{0}\n" //$NON-NLS-1$
+                + "},\n"; //$NON-NLS-1$
+    }
+}

--- a/bundles/com.codepilot1c.core/src/com/codepilot1c/core/edt/observability/eventlog/EventLogRecord.java
+++ b/bundles/com.codepilot1c.core/src/com/codepilot1c/core/edt/observability/eventlog/EventLogRecord.java
@@ -1,0 +1,143 @@
+package com.codepilot1c.core.edt.observability.eventlog;
+
+import com.google.gson.JsonObject;
+
+/**
+ * One decoded event-log entry. Field order in the source record (verified on a
+ * live 8.3.27 log): [0] date literal {@code yyyyMMddHHmmss}, [1] tx status,
+ * [2] tx id pair, [3] user seq, [4] computer seq, [5] application seq,
+ * [6] connection, [7] event seq, [8] severity code, [9] comment,
+ * [10] metadata seq, [11] data {type, value}, [12] data presentation,
+ * [13] server seq, [14/15] port seqs, [16] session.
+ */
+public final class EventLogRecord {
+
+    public long dateRaw;
+    public String dateIso;
+    public String txStatus;
+    public String user;
+    public String computer;
+    public String application;
+    public long connection;
+    public String event;
+    public String severity;
+    public String comment;
+    public String metadata;
+    public String dataType;
+    public String dataValue;
+    public String dataPresentation;
+    public String server;
+    public long session;
+
+    public static EventLogRecord decode(LgValue rec, LgfCatalog refs) {
+        if (rec == null || !rec.isList() || rec.items().size() < 17) {
+            return null;
+        }
+        Long date = rec.item(0).asLong();
+        if (date == null) {
+            return null;
+        }
+        EventLogRecord ev = new EventLogRecord();
+        ev.dateRaw = date;
+        ev.dateIso = toIso(date);
+        ev.txStatus = decodeTxStatus(text(rec, 1));
+        ev.user = refs.user(intAt(rec, 3));
+        ev.computer = refs.computer(intAt(rec, 4));
+        ev.application = refs.application(intAt(rec, 5));
+        Long conn = rec.item(6).asLong();
+        ev.connection = conn == null ? 0 : conn;
+        ev.event = refs.event(intAt(rec, 7));
+        ev.severity = decodeSeverity(text(rec, 8));
+        ev.comment = text(rec, 9);
+        ev.metadata = refs.metadataName(intAt(rec, 10));
+        LgValue data = rec.item(11);
+        if (data != null && data.isList() && !data.items().isEmpty()) {
+            ev.dataType = data.item(0) == null ? null : data.item(0).asString();
+            if (data.items().size() > 1 && data.item(1) != null && data.item(1).isAtom()) {
+                ev.dataValue = data.item(1).asString();
+            }
+        }
+        ev.dataPresentation = text(rec, 12);
+        ev.server = refs.server(intAt(rec, 13));
+        Long session = rec.item(16).asLong();
+        ev.session = session == null ? 0 : session;
+        return ev;
+    }
+
+    private static String text(LgValue rec, int index) {
+        LgValue v = rec.item(index);
+        return v == null ? null : v.asString();
+    }
+
+    private static int intAt(LgValue rec, int index) {
+        LgValue v = rec.item(index);
+        return v == null ? -1 : v.asInt(-1);
+    }
+
+    public static String decodeSeverity(String code) {
+        if (code == null) {
+            return null;
+        }
+        switch (code) {
+        case "I": return "Information"; //$NON-NLS-1$ //$NON-NLS-2$
+        case "W": return "Warning"; //$NON-NLS-1$ //$NON-NLS-2$
+        case "E": return "Error"; //$NON-NLS-1$ //$NON-NLS-2$
+        case "N": return "Note"; //$NON-NLS-1$ //$NON-NLS-2$
+        default: return code;
+        }
+    }
+
+    public static String decodeTxStatus(String code) {
+        if (code == null) {
+            return null;
+        }
+        switch (code) {
+        case "N": return "NotTransactional"; //$NON-NLS-1$ //$NON-NLS-2$
+        case "C": return "Committed"; //$NON-NLS-1$ //$NON-NLS-2$
+        case "U": return "Unfinished"; //$NON-NLS-1$ //$NON-NLS-2$
+        case "R": return "RolledBack"; //$NON-NLS-1$ //$NON-NLS-2$
+        default: return code;
+        }
+    }
+
+    /** {@code 20260814205206} → {@code 2026-08-14T20:52:06} (log-local time). */
+    public static String toIso(long ts) {
+        int yyyy = (int) (ts / 10_000_000_000L);
+        int mm = (int) ((ts / 100_000_000L) % 100);
+        int dd = (int) ((ts / 1_000_000L) % 100);
+        int hh = (int) ((ts / 10_000L) % 100);
+        int mi = (int) ((ts / 100L) % 100);
+        int ss = (int) (ts % 100);
+        return String.format("%04d-%02d-%02dT%02d:%02d:%02d", yyyy, mm, dd, hh, mi, ss); //$NON-NLS-1$
+    }
+
+    public JsonObject toJson() {
+        JsonObject o = new JsonObject();
+        o.addProperty("ts", dateIso); //$NON-NLS-1$
+        o.addProperty("severity", severity); //$NON-NLS-1$
+        o.addProperty("event", event); //$NON-NLS-1$
+        addIfPresent(o, "user", user); //$NON-NLS-1$
+        addIfPresent(o, "computer", computer); //$NON-NLS-1$
+        addIfPresent(o, "application", application); //$NON-NLS-1$
+        addIfPresent(o, "metadata", metadata); //$NON-NLS-1$
+        addIfPresent(o, "comment", comment); //$NON-NLS-1$
+        addIfPresent(o, "data_type", dataType); //$NON-NLS-1$
+        addIfPresent(o, "data_value", dataValue); //$NON-NLS-1$
+        addIfPresent(o, "data_presentation", dataPresentation); //$NON-NLS-1$
+        addIfPresent(o, "tx_status", "NotTransactional".equals(txStatus) ? null : txStatus); //$NON-NLS-1$ //$NON-NLS-2$
+        addIfPresent(o, "server", server); //$NON-NLS-1$
+        if (session != 0) {
+            o.addProperty("session", session); //$NON-NLS-1$
+        }
+        if (connection != 0) {
+            o.addProperty("connection", connection); //$NON-NLS-1$
+        }
+        return o;
+    }
+
+    private static void addIfPresent(JsonObject o, String key, String value) {
+        if (value != null && !value.isEmpty()) {
+            o.addProperty(key, value);
+        }
+    }
+}

--- a/bundles/com.codepilot1c.core/src/com/codepilot1c/core/edt/observability/eventlog/EventLogService.java
+++ b/bundles/com.codepilot1c.core/src/com/codepilot1c/core/edt/observability/eventlog/EventLogService.java
@@ -1,0 +1,345 @@
+package com.codepilot1c.core.edt.observability.eventlog;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.PushbackReader;
+import java.nio.channels.Channels;
+import java.nio.channels.SeekableByteChannel;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Reads the classic text event log ({@code 1Cv8Log/1Cv8.lgf} + daily
+ * {@code *.lgp} partitions) of a file infobase and answers filtered,
+ * newest-first queries with bounded scanning.
+ *
+ * <p>The SQLite variant ({@code 1Cv8Log/1Cv8.lgd}) is intentionally out of
+ * scope: this service reports it distinctly so the caller can suggest
+ * switching the infobase to the text format.</p>
+ */
+public final class EventLogService {
+
+    /** Hard cap on parsed records per query — CPU guard for huge logs. */
+    public static final int DEFAULT_SCAN_CAP = 500_000;
+
+    private static final Pattern FILE_CLAUSE = Pattern.compile("File=\"([^\"]+)\"", Pattern.CASE_INSENSITIVE); //$NON-NLS-1$
+    private static final Pattern PARTITION_NAME = Pattern.compile("(\\d{14})\\.lgp"); //$NON-NLS-1$
+
+    /** Query filter; {@code null}/empty members mean "no restriction". */
+    public static final class Query {
+        public long sinceRaw; // yyyyMMddHHmmss literal, 0 = open
+        public long untilRaw; // 0 = open
+        public Set<String> severities; // decoded names: Error, Warning, ...
+        public String eventContains;
+        public String userContains;
+        public String metadataContains;
+        public String textContains;
+        public int limit = 50;
+        public int offset;
+    }
+
+    public static final class Result {
+        public final List<EventLogRecord> records = new ArrayList<>();
+        public long matched;
+        public long scanned;
+        public int partitionsScanned;
+        public boolean hasMore;
+        public boolean scanCapHit;
+        public boolean partialTail;
+    }
+
+    private final int scanCap;
+
+    public EventLogService() {
+        this(DEFAULT_SCAN_CAP);
+    }
+
+    public EventLogService(int scanCap) {
+        this.scanCap = scanCap;
+    }
+
+    /** Extracts the {@code File="..."} path from a 1C connection string, or {@code null}. */
+    public static Path infobasePathFromConnectionString(String connectionString) {
+        if (connectionString == null) {
+            return null;
+        }
+        Matcher m = FILE_CLAUSE.matcher(connectionString);
+        return m.find() ? Path.of(m.group(1)) : null;
+    }
+
+    public static Path logDirOf(Path infobaseDir) {
+        return infobaseDir == null ? null : infobaseDir.resolve("1Cv8Log"); //$NON-NLS-1$
+    }
+
+    public static boolean isSqliteFormat(Path logDir) {
+        return logDir != null && Files.isRegularFile(logDir.resolve("1Cv8.lgd")); //$NON-NLS-1$
+    }
+
+    /**
+     * Runs the query over the log directory: partitions are visited newest
+     * first, matches inside each partition are reversed to keep the overall
+     * newest-first order, and the walk stops as soon as {@code offset+limit}
+     * matches are collected (older partitions are then irrelevant).
+     */
+    public Result query(Path logDir, Query q) throws IOException {
+        Result result = new Result();
+        LgfCatalog refs = LgfCatalog.load(logDir.resolve("1Cv8.lgf")); //$NON-NLS-1$
+        List<Path> partitions = partitionsNewestFirst(logDir, q);
+        int needed = q.offset + Math.max(q.limit, 0);
+        List<EventLogRecord> collected = new ArrayList<>();
+        for (Path lgp : partitions) {
+            if (collected.size() >= needed || result.scanned >= scanCap) {
+                result.hasMore = result.hasMore || collected.size() >= needed;
+                break;
+            }
+            result.partitionsScanned++;
+            List<EventLogRecord> partitionMatches = new ArrayList<>();
+            boolean torn = scanPartition(lgp, refs, q, result, partitionMatches);
+            result.partialTail |= torn;
+            Collections.reverse(partitionMatches);
+            collected.addAll(partitionMatches);
+        }
+        result.matched = collected.size();
+        int from = Math.min(q.offset, collected.size());
+        int to = Math.min(from + Math.max(q.limit, 0), collected.size());
+        result.records.addAll(collected.subList(from, to));
+        result.hasMore = result.hasMore || to < collected.size();
+        result.scanCapHit = result.scanned >= scanCap;
+        return result;
+    }
+
+    /**
+     * Byte offset of the first record whose stamp is at or after {@code sinceRaw}.
+     *
+     * <p>Why this exists: partitions are visited newest first, but INSIDE a
+     * partition the parse used to start at byte zero. A single busy day easily
+     * exceeds {@link #DEFAULT_SCAN_CAP}, so the budget was spent on records far
+     * older than the requested window and the scan never reached the tail — the
+     * query answered "nothing found" for a window that was full of records.
+     * Observed 2026-08-18 on a 76 MB daily partition: a {@code since} one hour
+     * back returned empty while the log kept growing.</p>
+     *
+     * <p>Records are append-ordered and every top-level record starts a line
+     * with <code>{yyyyMMddHHmmss,</code>, so a plain binary search over byte
+     * offsets finds the window start without parsing the prefix at all.</p>
+     *
+     * @return offset to start parsing at; file size when nothing is in window.
+     */
+    private static long windowStartOffset(Path lgp, long sinceRaw) throws IOException {
+        long size = Files.size(lgp);
+        if (sinceRaw <= 0 || size == 0) {
+            return 0L;
+        }
+        try (SeekableByteChannel channel = Files.newByteChannel(lgp)) {
+            // Bounds move by mid, NOT by the offset of the record found at or
+            // after mid: that offset is >= mid and can equal hi, so the interval
+            // stops shrinking and the search spins forever. The first build of
+            // this fix did exactly that and the query timed out instead of
+            // answering.
+            long lo = 0L;
+            long hi = size;
+            while (lo < hi) {
+                long mid = lo + (hi - lo) / 2;
+                long[] found = recordAtOrAfter(channel, mid, size);
+                if (found == null || found[1] >= sinceRaw) {
+                    hi = mid;
+                } else {
+                    lo = mid + 1;
+                }
+            }
+            long[] window = recordAtOrAfter(channel, lo, size);
+            // Starting slightly before the window is safe: matches() still applies since.
+            return window == null ? size : window[0];
+        }
+    }
+
+    /**
+     * First top-level record start at or after {@code from}.
+     *
+     * @return {@code [offset, stamp]} or {@code null} when none is left.
+     */
+    private static long[] recordAtOrAfter(SeekableByteChannel channel, long from, long size)
+            throws IOException {
+        final int window = 64 * 1024;
+        long position = from;
+        java.nio.ByteBuffer buffer = java.nio.ByteBuffer.allocate(window);
+        StringBuilder carry = new StringBuilder();
+        long carryOffset = from;
+        while (position < size) {
+            channel.position(position);
+            buffer.clear();
+            int read = channel.read(buffer);
+            if (read <= 0) {
+                return null;
+            }
+            String chunk = new String(buffer.array(), 0, read, StandardCharsets.ISO_8859_1);
+            carry.append(chunk);
+            int lineStart = 0;
+            while (true) {
+                int newline = carry.indexOf("\n", lineStart); //$NON-NLS-1$
+                if (newline < 0) {
+                    break;
+                }
+                int candidate = newline + 1;
+                // A record header spans 16 chars. When they are not read yet the
+                // candidate is kept in the carry buffer for the next block instead
+                // of being dropped: otherwise a boundary landing on a read-block
+                // edge is silently missed.
+                if (candidate + 16 > carry.length()) {
+                    break;
+                }
+                Long stamp = stampAt(carry, candidate);
+                if (stamp != null) {
+                    return new long[] { carryOffset + candidate, stamp };
+                }
+                lineStart = candidate;
+            }
+            carry.delete(0, lineStart);
+            carryOffset += lineStart;
+            position += read;
+        }
+        return null;
+    }
+
+    /** Stamp of a record header line {@code {yyyyMMddHHmmss,} at {@code index}, or null. */
+    private static Long stampAt(CharSequence text, int index) {
+        if (index + 16 > text.length()) {
+            return null;
+        }
+        if (text.charAt(index) != '{' || text.charAt(index + 15) != ',') {
+            return null;
+        }
+        long stamp = 0;
+        for (int i = index + 1; i < index + 15; i++) {
+            char c = text.charAt(i);
+            if (c < '0' || c > '9') {
+                return null;
+            }
+            stamp = stamp * 10 + (c - '0');
+        }
+        return stamp;
+    }
+
+    /** @return true when the partition tail was torn mid-record (active file). */
+    private boolean scanPartition(Path lgp, LgfCatalog refs, Query q, Result result,
+            List<EventLogRecord> sink) throws IOException {
+        long start = windowStartOffset(lgp, q.sinceRaw);
+        if (start >= Files.size(lgp) && q.sinceRaw > 0) {
+            return false; // whole partition is older than the window
+        }
+        SeekableByteChannel channel = Files.newByteChannel(lgp);
+        channel.position(start);
+        try (BufferedReader br = new BufferedReader(
+                new InputStreamReader(Channels.newInputStream(channel), StandardCharsets.UTF_8));
+                PushbackReader reader = new PushbackReader(br, 1)) {
+            skipHeader(reader);
+            while (result.scanned < scanCap) {
+                LgValue rec;
+                try {
+                    rec = LgValue.readRecord(reader);
+                } catch (LgValue.TruncatedRecordException e) {
+                    return true;
+                }
+                if (rec == null) {
+                    return false;
+                }
+                EventLogRecord ev = EventLogRecord.decode(rec, refs);
+                if (ev == null) {
+                    continue; // header block or malformed entry
+                }
+                result.scanned++;
+                if (matches(ev, q)) {
+                    sink.add(ev);
+                }
+            }
+            return false;
+        }
+    }
+
+    /**
+     * The partition starts with {@code 1CV8LOG(ver 2.0)}, a UUID line and an
+     * open-brace-free preamble; {@link LgValue#readRecord} already skips
+     * anything before the first top-level brace, and the first brace block of
+     * a partition is an ordinary record, so no extra work is needed. Kept as a
+     * hook should the format grow a real header block.
+     */
+    private static void skipHeader(PushbackReader reader) {
+        // intentionally empty
+    }
+
+    private static boolean matches(EventLogRecord ev, Query q) {
+        if (q.sinceRaw > 0 && ev.dateRaw < q.sinceRaw) {
+            return false;
+        }
+        if (q.untilRaw > 0 && ev.dateRaw > q.untilRaw) {
+            return false;
+        }
+        if (q.severities != null && !q.severities.isEmpty()
+                && (ev.severity == null || !q.severities.contains(ev.severity))) {
+            return false;
+        }
+        if (!containsIgnoreCase(ev.event, q.eventContains)) {
+            return false;
+        }
+        if (!containsIgnoreCase(ev.user, q.userContains)) {
+            return false;
+        }
+        if (!containsIgnoreCase(ev.metadata, q.metadataContains)) {
+            return false;
+        }
+        if (q.textContains != null && !q.textContains.isEmpty()) {
+            return containsIgnoreCase(ev.comment, q.textContains)
+                    || containsIgnoreCase(ev.dataPresentation, q.textContains)
+                    || containsIgnoreCase(ev.dataValue, q.textContains);
+        }
+        return true;
+    }
+
+    private static boolean containsIgnoreCase(String haystack, String needle) {
+        if (needle == null || needle.isEmpty()) {
+            return true;
+        }
+        return haystack != null
+                && haystack.toLowerCase(Locale.ROOT).contains(needle.toLowerCase(Locale.ROOT));
+    }
+
+    /**
+     * Partitions carry their day in the file name ({@code yyyyMMdd000000.lgp});
+     * a partition is skipped when its whole day lies outside the query window.
+     */
+    private List<Path> partitionsNewestFirst(Path logDir, Query q) throws IOException {
+        List<Path> out = new ArrayList<>();
+        if (!Files.isDirectory(logDir)) {
+            return out;
+        }
+        try (DirectoryStream<Path> stream = Files.newDirectoryStream(logDir, "*.lgp")) { //$NON-NLS-1$
+            for (Path p : stream) {
+                Matcher m = PARTITION_NAME.matcher(p.getFileName().toString());
+                if (!m.matches()) {
+                    continue;
+                }
+                long dayStart = Long.parseLong(m.group(1));
+                long dayEnd = dayStart + 235959; // same-day upper literal bound
+                if (q.sinceRaw > 0 && dayEnd < q.sinceRaw) {
+                    continue;
+                }
+                if (q.untilRaw > 0 && dayStart > q.untilRaw) {
+                    continue;
+                }
+                out.add(p);
+            }
+        }
+        out.sort((a, b) -> b.getFileName().toString().compareTo(a.getFileName().toString()));
+        return out;
+    }
+}

--- a/bundles/com.codepilot1c.core/src/com/codepilot1c/core/edt/observability/eventlog/LgValue.java
+++ b/bundles/com.codepilot1c.core/src/com/codepilot1c/core/edt/observability/eventlog/LgValue.java
@@ -1,0 +1,174 @@
+package com.codepilot1c.core.edt.observability.eventlog;
+
+import java.io.IOException;
+import java.io.PushbackReader;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Node of the 1C text event-log serialization ({@code 1Cv8.lgf} / {@code *.lgp}):
+ * either an atom (bare token or quoted string) or a brace-list of nested values.
+ *
+ * <p>Format essentials (verified against a live 8.3.27 file-infobase log; field
+ * mapping cross-checked with the ru.fedukhin.edt.mcp eventlog bundle, Apache-2.0):
+ * records are top-level {@code {...}} blocks separated by commas/newlines; strings
+ * are double-quoted with {@code ""} escaping; atoms are numbers, UUIDs or letter
+ * codes such as {@code I}/{@code N}.</p>
+ */
+public final class LgValue {
+
+    private final String atom;
+    private final List<LgValue> items;
+
+    private LgValue(String atom, List<LgValue> items) {
+        this.atom = atom;
+        this.items = items;
+    }
+
+    public static LgValue atom(String text) {
+        return new LgValue(text, null);
+    }
+
+    public static LgValue list(List<LgValue> items) {
+        return new LgValue(null, items);
+    }
+
+    public boolean isList() {
+        return items != null;
+    }
+
+    public boolean isAtom() {
+        return atom != null;
+    }
+
+    public List<LgValue> items() {
+        return items == null ? List.of() : items;
+    }
+
+    /** Atom text, or {@code null} for lists; never throws. */
+    public String asString() {
+        return atom;
+    }
+
+    public Long asLong() {
+        if (atom == null || atom.isEmpty()) {
+            return null;
+        }
+        try {
+            return Long.valueOf(atom);
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    public int asInt(int fallback) {
+        Long v = asLong();
+        return v == null ? fallback : v.intValue();
+    }
+
+    /** Nested item by index or {@code null} when out of range / not a list. */
+    public LgValue item(int index) {
+        if (items == null || index < 0 || index >= items.size()) {
+            return null;
+        }
+        return items.get(index);
+    }
+
+    /**
+     * Reads the next top-level {@code {...}} block, skipping separators between
+     * records. Returns {@code null} on clean EOF and throws
+     * {@link TruncatedRecordException} when EOF hits inside a record — the normal
+     * state of the tail of the partition currently being written.
+     */
+    public static LgValue readRecord(PushbackReader reader) throws IOException {
+        int c;
+        do {
+            c = reader.read();
+            if (c < 0) {
+                return null;
+            }
+        } while (c != '{');
+        return parseList(reader);
+    }
+
+    private static LgValue parseList(PushbackReader reader) throws IOException {
+        List<LgValue> out = new ArrayList<>();
+        while (true) {
+            int c = readSkippingEol(reader);
+            if (c < 0) {
+                throw new TruncatedRecordException();
+            }
+            switch (c) {
+            case '{':
+                out.add(parseList(reader));
+                break;
+            case '}':
+                return list(out);
+            case ',':
+                // separator; empty positions between commas are not produced by 1C
+                break;
+            case '"':
+                out.add(atom(parseQuoted(reader)));
+                break;
+            default:
+                reader.unread(c);
+                out.add(atom(parseBareAtom(reader)));
+                break;
+            }
+        }
+    }
+
+    private static String parseBareAtom(PushbackReader reader) throws IOException {
+        StringBuilder sb = new StringBuilder();
+        while (true) {
+            int c = reader.read();
+            if (c < 0) {
+                throw new TruncatedRecordException();
+            }
+            if (c == ',' || c == '}') {
+                reader.unread(c);
+                return sb.toString();
+            }
+            if (c == '\r' || c == '\n' || c == ' ' || c == '\t') {
+                continue;
+            }
+            sb.append((char) c);
+        }
+    }
+
+    private static String parseQuoted(PushbackReader reader) throws IOException {
+        StringBuilder sb = new StringBuilder();
+        while (true) {
+            int c = reader.read();
+            if (c < 0) {
+                throw new TruncatedRecordException();
+            }
+            if (c == '"') {
+                int next = reader.read();
+                if (next == '"') {
+                    sb.append('"');
+                    continue;
+                }
+                if (next >= 0) {
+                    reader.unread(next);
+                }
+                return sb.toString();
+            }
+            sb.append((char) c);
+        }
+    }
+
+    private static int readSkippingEol(PushbackReader reader) throws IOException {
+        while (true) {
+            int c = reader.read();
+            if (c != '\r' && c != '\n' && c != ' ' && c != '\t') {
+                return c;
+            }
+        }
+    }
+
+    /** EOF inside a record — active-partition tail, not an error for the file. */
+    public static final class TruncatedRecordException extends IOException {
+        private static final long serialVersionUID = 1L;
+    }
+}

--- a/bundles/com.codepilot1c.core/src/com/codepilot1c/core/edt/observability/eventlog/LgfCatalog.java
+++ b/bundles/com.codepilot1c.core/src/com/codepilot1c/core/edt/observability/eventlog/LgfCatalog.java
@@ -1,0 +1,153 @@
+package com.codepilot1c.core.edt.observability.eventlog;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.PushbackReader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Reference dictionaries from {@code 1Cv8.lgf}: event-log records store integer
+ * sequence ids instead of names; this catalog resolves them back.
+ *
+ * <p>Entry kinds (first atom of each block): 1 = user {@code {1,uuid,"name",seq}},
+ * 2 = computer, 3 = application, 4 = event, 5 = metadata
+ * {@code {5,uuid,"fullName",seq}}, 6 = working server, 7/8 = ports. Other kinds
+ * are ignored.</p>
+ */
+public final class LgfCatalog {
+
+    private final Map<Integer, String> users = new HashMap<>();
+    private final Map<Integer, String> userUuids = new HashMap<>();
+    private final Map<Integer, String> computers = new HashMap<>();
+    private final Map<Integer, String> applications = new HashMap<>();
+    private final Map<Integer, String> events = new HashMap<>();
+    private final Map<Integer, String> metadata = new HashMap<>();
+    private final Map<Integer, String> metadataUuids = new HashMap<>();
+    private final Map<Integer, String> servers = new HashMap<>();
+
+    public static LgfCatalog load(Path lgf) throws IOException {
+        LgfCatalog catalog = new LgfCatalog();
+        if (lgf == null || !Files.isRegularFile(lgf)) {
+            return catalog;
+        }
+        try (BufferedReader br = Files.newBufferedReader(lgf, StandardCharsets.UTF_8);
+                PushbackReader reader = new PushbackReader(br, 1)) {
+            while (true) {
+                LgValue rec;
+                try {
+                    rec = LgValue.readRecord(reader);
+                } catch (LgValue.TruncatedRecordException e) {
+                    break; // catalog is appended live too; a torn tail is normal
+                }
+                if (rec == null) {
+                    break;
+                }
+                catalog.accept(rec);
+            }
+        }
+        return catalog;
+    }
+
+    private void accept(LgValue rec) {
+        if (!rec.isList() || rec.items().isEmpty()) {
+            return;
+        }
+        int kind = rec.item(0) == null ? -1 : rec.item(0).asInt(-1);
+        switch (kind) {
+        case 1: { // {1, uuid, "name", seq}
+            String uuid = textAt(rec, 1);
+            String name = textAt(rec, 2);
+            Integer seq = intAt(rec, 3);
+            if (seq != null) {
+                users.put(seq, name);
+                userUuids.put(seq, uuid);
+            }
+            break;
+        }
+        case 2:
+            put(computers, rec);
+            break;
+        case 3:
+            put(applications, rec);
+            break;
+        case 4:
+            put(events, rec);
+            break;
+        case 5: { // {5, uuid, "fullName", seq}
+            String uuid = textAt(rec, 1);
+            String name = textAt(rec, 2);
+            Integer seq = intAt(rec, 3);
+            if (seq != null) {
+                metadata.put(seq, name);
+                metadataUuids.put(seq, uuid);
+            }
+            break;
+        }
+        case 6:
+            put(servers, rec);
+            break;
+        default:
+            break;
+        }
+    }
+
+    /** Common shape {@code {kind, "name", seq}}. */
+    private static void put(Map<Integer, String> target, LgValue rec) {
+        String name = textAt(rec, 1);
+        Integer seq = intAt(rec, 2);
+        if (seq != null) {
+            target.put(seq, name);
+        }
+    }
+
+    private static String textAt(LgValue rec, int index) {
+        LgValue v = rec.item(index);
+        return v == null ? null : v.asString();
+    }
+
+    private static Integer intAt(LgValue rec, int index) {
+        LgValue v = rec.item(index);
+        Long n = v == null ? null : v.asLong();
+        return n == null ? null : n.intValue();
+    }
+
+    public String user(int seq) {
+        return users.get(seq);
+    }
+
+    public String userUuid(int seq) {
+        return userUuids.get(seq);
+    }
+
+    public String computer(int seq) {
+        return computers.get(seq);
+    }
+
+    public String application(int seq) {
+        return applications.get(seq);
+    }
+
+    public String event(int seq) {
+        return events.get(seq);
+    }
+
+    public String metadataName(int seq) {
+        return metadata.get(seq);
+    }
+
+    public String metadataUuid(int seq) {
+        return metadataUuids.get(seq);
+    }
+
+    public String server(int seq) {
+        return servers.get(seq);
+    }
+
+    public int eventCount() {
+        return events.size();
+    }
+}

--- a/bundles/com.codepilot1c.core/src/com/codepilot1c/core/tools/ToolRegistry.java
+++ b/bundles/com.codepilot1c.core/src/com/codepilot1c/core/tools/ToolRegistry.java
@@ -168,6 +168,7 @@ public class ToolRegistry {
         register(new EdtDiagnosticsTool());
         register(new GetOneCProcessesTool());
         register(new GetInfobaseLocksTool());
+        register(new QueryEventLogTool());
         register(new GetStandaloneServerStatusTool());
         register(new ResolveWebClientUrlTool());
         register(new GetInfobaseCredentialsTool());

--- a/bundles/com.codepilot1c.core/src/com/codepilot1c/core/tools/diagnostics/QueryEventLogTool.java
+++ b/bundles/com.codepilot1c.core/src/com/codepilot1c/core/tools/diagnostics/QueryEventLogTool.java
@@ -1,0 +1,245 @@
+package com.codepilot1c.core.tools.diagnostics;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+
+import org.eclipse.core.resources.ResourcesPlugin;
+
+import com._1c.g5.v8.dt.platform.services.model.InfobaseReference;
+import com.codepilot1c.core.edt.observability.eventlog.EventLogRecord;
+import com.codepilot1c.core.edt.observability.eventlog.EventLogService;
+import com.codepilot1c.core.edt.runtime.EdtProjectResolver;
+import com.codepilot1c.core.logging.LogSanitizer;
+import com.codepilot1c.core.logging.VibeLogger;
+import com.codepilot1c.core.tools.AbstractTool;
+import com.codepilot1c.core.tools.ToolMeta;
+import com.codepilot1c.core.tools.ToolParameters;
+import com.codepilot1c.core.tools.ToolResult;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+
+/**
+ * Queries the 1C event log ({@code 1Cv8Log}) of a file infobase associated with
+ * an EDT project — newest first, with severity/event/user/metadata/text filters.
+ * Closes the "read the registration journal from the agent loop" gap: BSP-level
+ * errors surface here when EDT diagnostics and test runs stay silent.
+ */
+@ToolMeta(name = "query_event_log", category = "diagnostics", tags = {"read-only", "infobase", "diagnostics"})
+public class QueryEventLogTool extends AbstractTool {
+
+    private static final VibeLogger.CategoryLogger LOG = VibeLogger.forClass(QueryEventLogTool.class);
+    private static final String TOOL_NAME = "query_event_log"; //$NON-NLS-1$
+    private static final int MAX_LIMIT = 500;
+
+    private static final String SCHEMA = """
+            {
+              "type": "object",
+              "properties": {
+                "project": {"type": "string", "description": "EDT project with an infobase association (base project, not an extension)"},
+                "log_dir": {"type": "string", "description": "Explicit path to a 1Cv8Log directory; overrides project resolution"},
+                "since": {"type": "string", "description": "Lower bound, ISO 2026-08-14T20:00:00 or literal 20260814200000"},
+                "until": {"type": "string", "description": "Upper bound, same formats"},
+                "last_minutes": {"type": "integer", "description": "Shortcut: since = now - last_minutes (ignored when since is set)"},
+                "severity": {"type": "array", "items": {"type": "string"}, "description": "Any of Error, Warning, Information, Note (or codes E/W/I/N)"},
+                "event_contains": {"type": "string"},
+                "user_contains": {"type": "string"},
+                "metadata_contains": {"type": "string"},
+                "text_contains": {"type": "string", "description": "Substring over comment, data value and data presentation"},
+                "limit": {"type": "integer", "description": "Max records to return, default 50, cap 500"},
+                "offset": {"type": "integer"}
+              },
+              "additionalProperties": false
+            }
+            """; //$NON-NLS-1$
+
+    private final EventLogService service;
+    private final EdtProjectResolver projectResolver;
+
+    public QueryEventLogTool() {
+        this(new EventLogService(), new EdtProjectResolver());
+    }
+
+    public QueryEventLogTool(EventLogService service, EdtProjectResolver projectResolver) {
+        this.service = service;
+        this.projectResolver = projectResolver;
+    }
+
+    @Override
+    public String getDescription() {
+        return "Reads the 1C event log (registration journal) of a file infobase: newest-first records " //$NON-NLS-1$
+                + "with severity/event/user/metadata/text filters. Resolve via EDT project association " //$NON-NLS-1$
+                + "or an explicit 1Cv8Log path."; //$NON-NLS-1$
+    }
+
+    @Override
+    public String getParameterSchema() {
+        return SCHEMA;
+    }
+
+    @Override
+    protected CompletableFuture<ToolResult> doExecute(ToolParameters params) {
+        return CompletableFuture.supplyAsync(() -> {
+            String opId = LogSanitizer.newId("evlog"); //$NON-NLS-1$
+            Map<String, Object> raw = params.getRaw();
+            try {
+                Path logDir = resolveLogDir(raw);
+                if (logDir == null) {
+                    return failure(opId, "INVALID_ARGUMENT", //$NON-NLS-1$
+                            "Pass either project (with infobase association) or log_dir"); //$NON-NLS-1$
+                }
+                if (EventLogService.isSqliteFormat(logDir)) {
+                    return failure(opId, "SQLITE_LOG_FORMAT", //$NON-NLS-1$
+                            "The infobase writes its event log in SQLite format (1Cv8.lgd); " //$NON-NLS-1$
+                                    + "only the text format is supported — switch the log format " //$NON-NLS-1$
+                                    + "or query the .lgd file with external tooling"); //$NON-NLS-1$
+                }
+                if (!Files.isDirectory(logDir)) {
+                    return failure(opId, "LOG_DIR_NOT_FOUND", //$NON-NLS-1$
+                            "Event log directory does not exist: " + logDir); //$NON-NLS-1$
+                }
+                EventLogService.Query query = buildQuery(raw, params);
+                LOG.info("[%s] query_event_log dir=%s since=%d until=%d limit=%d", //$NON-NLS-1$
+                        opId, logDir, query.sinceRaw, query.untilRaw, query.limit);
+                EventLogService.Result r = service.query(logDir, query);
+                JsonObject payload = new JsonObject();
+                payload.addProperty("log_dir", logDir.toString()); //$NON-NLS-1$
+                JsonArray records = new JsonArray();
+                for (EventLogRecord ev : r.records) {
+                    records.add(ev.toJson());
+                }
+                payload.add("records", records); //$NON-NLS-1$
+                payload.addProperty("returned", r.records.size()); //$NON-NLS-1$
+                payload.addProperty("matched", r.matched); //$NON-NLS-1$
+                payload.addProperty("scanned", r.scanned); //$NON-NLS-1$
+                payload.addProperty("partitions_scanned", r.partitionsScanned); //$NON-NLS-1$
+                payload.addProperty("has_more", r.hasMore); //$NON-NLS-1$
+                if (r.scanCapHit) {
+                    payload.addProperty("scan_cap_hit", true); //$NON-NLS-1$
+                }
+                if (r.partialTail) {
+                    payload.addProperty("partial_tail", true); //$NON-NLS-1$
+                }
+                return ToolResult.success(new GsonBuilder().setPrettyPrinting().create().toJson(payload),
+                        ToolResult.ToolResultType.CODE);
+            } catch (Exception e) {
+                LOG.error("[%s] query_event_log failed: %s", opId, String.valueOf(e.getMessage())); //$NON-NLS-1$
+                return failure(opId, "EVENT_LOG_READ_FAILED", String.valueOf(e.getMessage())); //$NON-NLS-1$
+            }
+        });
+    }
+
+    private Path resolveLogDir(Map<String, Object> raw) {
+        String explicit = asString(raw.get("log_dir")); //$NON-NLS-1$
+        if (!explicit.isBlank()) {
+            Path p = Path.of(explicit);
+            // accept both the 1Cv8Log dir itself and the infobase root above it
+            if (Files.isDirectory(p.resolve("1Cv8Log"))) { //$NON-NLS-1$
+                return p.resolve("1Cv8Log"); //$NON-NLS-1$
+            }
+            return p;
+        }
+        String project = asString(raw.get("project")); //$NON-NLS-1$
+        if (project.isBlank()) {
+            return null;
+        }
+        File workspaceRoot = ResourcesPlugin.getWorkspace().getRoot().getLocation().toFile();
+        InfobaseReference infobase = projectResolver.resolveInfobase(project, workspaceRoot);
+        if (infobase == null || infobase.getConnectionString() == null) {
+            return null;
+        }
+        Path infobasePath = EventLogService
+                .infobasePathFromConnectionString(infobase.getConnectionString().asConnectionString());
+        return EventLogService.logDirOf(infobasePath);
+    }
+
+    private static EventLogService.Query buildQuery(Map<String, Object> raw, ToolParameters params) {
+        EventLogService.Query q = new EventLogService.Query();
+        q.sinceRaw = parseMoment(asString(raw.get("since"))); //$NON-NLS-1$
+        q.untilRaw = parseMoment(asString(raw.get("until"))); //$NON-NLS-1$
+        int lastMinutes = params.optInt("last_minutes", 0); //$NON-NLS-1$
+        if (q.sinceRaw == 0 && lastMinutes > 0) {
+            q.sinceRaw = literalMinutesAgo(lastMinutes);
+        }
+        q.severities = parseSeverities(raw.get("severity")); //$NON-NLS-1$
+        q.eventContains = asString(raw.get("event_contains")); //$NON-NLS-1$
+        q.userContains = asString(raw.get("user_contains")); //$NON-NLS-1$
+        q.metadataContains = asString(raw.get("metadata_contains")); //$NON-NLS-1$
+        q.textContains = asString(raw.get("text_contains")); //$NON-NLS-1$
+        q.limit = Math.min(Math.max(params.optInt("limit", 50), 0), MAX_LIMIT); //$NON-NLS-1$
+        q.offset = Math.max(params.optInt("offset", 0), 0); //$NON-NLS-1$
+        return q;
+    }
+
+    /** Accepts {@code 2026-08-14T20:00:00}, {@code 2026-08-14 20:00:00} or a raw 14-digit literal. */
+    static long parseMoment(String value) {
+        if (value == null || value.isBlank()) {
+            return 0;
+        }
+        String digits = value.replaceAll("\\D", ""); //$NON-NLS-1$ //$NON-NLS-2$
+        if (digits.length() >= 14) {
+            return Long.parseLong(digits.substring(0, 14));
+        }
+        if (digits.length() == 8) { // date only → start of day
+            return Long.parseLong(digits) * 1_000_000L;
+        }
+        return 0;
+    }
+
+    private static long literalMinutesAgo(int minutes) {
+        java.time.LocalDateTime t = java.time.LocalDateTime.now().minusMinutes(minutes);
+        return t.getYear() * 10_000_000_000L + t.getMonthValue() * 100_000_000L
+                + t.getDayOfMonth() * 1_000_000L + t.getHour() * 10_000L
+                + t.getMinute() * 100L + t.getSecond();
+    }
+
+    private static Set<String> parseSeverities(Object value) {
+        if (!(value instanceof List<?> list) || list.isEmpty()) {
+            return null;
+        }
+        Set<String> out = new HashSet<>();
+        for (Object item : list) {
+            String s = String.valueOf(item).strip();
+            if (s.length() == 1) {
+                s = EventLogRecord.decodeSeverity(s.toUpperCase(Locale.ROOT));
+            } else {
+                s = normalizeSeverityName(s);
+            }
+            if (s != null && !s.isEmpty()) {
+                out.add(s);
+            }
+        }
+        return out.isEmpty() ? null : out;
+    }
+
+    private static String normalizeSeverityName(String s) {
+        switch (s.toLowerCase(Locale.ROOT)) {
+        case "error": case "ошибка": return "Error"; //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+        case "warning": case "предупреждение": return "Warning"; //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+        case "information": case "информация": return "Information"; //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+        case "note": case "примечание": return "Note"; //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+        default: return s;
+        }
+    }
+
+    private ToolResult failure(String opId, String code, String message) {
+        JsonObject error = new JsonObject();
+        error.addProperty("op_id", opId); //$NON-NLS-1$
+        error.addProperty("tool", TOOL_NAME); //$NON-NLS-1$
+        error.addProperty("code", code); //$NON-NLS-1$
+        error.addProperty("message", message); //$NON-NLS-1$
+        return ToolResult.failure("[" + code + "] " + message + "\n" //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+                + new GsonBuilder().setPrettyPrinting().create().toJson(error));
+    }
+
+    private static String asString(Object value) {
+        return value == null ? "" : String.valueOf(value).strip(); //$NON-NLS-1$
+    }
+}


### PR DESCRIPTION
## Что добавляет

Тул `query_event_log` — чтение журнала регистрации **файловой** информационной базы прямо из MCP: `1Cv8Log` (каталог `1Cv8.lgf` + дневные партиции `*.lgp`). Фильтры — временное окно, важность, событие, пользователь, метаданные и свободный текст по комментарию и данным. Ответ — свежие записи первыми.

Вариант журнала в SQLite (`1Cv8.lgd`) распознаётся и честно сообщается отдельно, а не разбирается наполовину: вызывающий может подсказать переключить формат.

## Зачем это в MCP, а не «руками посмотреть»

Журнал регистрации — то место, где проглоченный серверный отказ всё равно оставляет след. Когда журнал доступен из MCP, автоматический гейт может после прогона тестов проверить «новых ошибок с отсечки нет». Это ловит целый класс дефектов, где тест зелёный, потому что исключение перехватили и записали в журнал вместо того, чтобы отдать наружу.

У нас на этом стоит гейт регрессионного прогона, и он на такой находке уже сработал.

## Про ограничение скана

Скан ограничен потолком разобранных записей, но обход **встаёт сразу на запрошенное окно**, а не читает партицию с нулевого байта: партиции обходятся с новых, а внутри партиции начало окна ищется двоичным поиском по смещению.

Без этого один загруженный день перекрывает потолок, бюджет тратится на записи много старше окна, и запрос возвращает пустой список — неотличимый от честно тихого окна. Для запроса, на котором висит гейт, это худший вид отказа. Замер на дневной партиции 76 МБ: `scanned` падает с потолка 500 000 до 70 000, записи возвращаются.

Две ловушки самого поиска оставлены комментариями в коде, чтобы их не внесли обратно:

- границы двигать по `mid`, а не по смещению найденной записи — оно может совпасть с `hi`, интервал перестаёт сужаться и поиск виснет;
- заголовок записи занимает 16 символов, поэтому граница, попавшая на стык блоков чтения, должна оставаться в буфере, иначе теряется молча.

## Тест

`EventLogServiceSinceWindowTest` строит синтетическую партицию заведомо больше потолка и проверяет, что запись в окне находится. Тест красный на реализации без поиска окна — `expected:<1> but was:<0>` — и зелёный после. Проверено парным прогоном на обеих версиях.

## Мелочи

- Русские алиасы важности принимаются наравне с английскими: платформа пишет журнал в локали.
- Регистрация — одна строка в `ToolRegistry` рядом с прочими диагностическими тулами.
- Новых зависимостей нет: используются существующие `AbstractTool`, `ToolMeta`, `ToolParameters`, `ToolResult`, `VibeLogger`, `LogSanitizer`, `EdtProjectResolver`.
- Собрано на `origin/main` (`mvn -DskipTests package`), модуль core — SUCCESS.

Замечания по стилю и структуре поправлю, если что-то расходится с принятым в проекте.