### PR TITLE
metadata: вложенные подсистемы читаются, непарный FQN отбивается

### DIFF
--- a/bundles/com.codepilot1c.core/src/com/codepilot1c/core/edt/ast/EdtMetadataInspectorService.java
+++ b/bundles/com.codepilot1c.core/src/com/codepilot1c/core/edt/ast/EdtMetadataInspectorService.java
@@ -19,6 +19,7 @@ import com._1c.g5.v8.dt.core.platform.IConfigurationProvider;
 import com._1c.g5.v8.dt.metadata.mdclass.Configuration;
 import com._1c.g5.v8.dt.metadata.mdclass.MdObject;
 import com.codepilot1c.core.edt.BmObjectHelper;
+import com.codepilot1c.core.edt.metadata.MdObjectFqnResolver;
 import com.codepilot1c.core.edt.metadata.MetadataConfigurationCollections;
 import com.codepilot1c.core.edt.metadata.MetadataKind;
 import com.codepilot1c.core.edt.metadata.MetadataOperationException;
@@ -62,7 +63,11 @@ public class EdtMetadataInspectorService {
                         .setPath(fqn)
                         .setFormatStyle(MetadataNode.FormatStyle.SIMPLE_VALUE)
                         .putProperty("exists", Boolean.FALSE) //$NON-NLS-1$
-                        .putProperty("message", "Object not found"); //$NON-NLS-1$ //$NON-NLS-2$
+                        .putProperty("message", //$NON-NLS-1$
+                                MdObjectFqnResolver.hasCompleteSegmentPairs(fqn.split("\\.")) //$NON-NLS-1$
+                                        ? "Object not found" //$NON-NLS-1$
+                                        : "Malformed FQN: segments after <Type>.<Name> must be marker/name pairs, " //$NON-NLS-1$
+                                                + "e.g. Subsystem.Родитель.Subsystem.Вложенная"); //$NON-NLS-1$
                 nodes.add(missing);
                 continue;
             }
@@ -157,14 +162,15 @@ public class EdtMetadataInspectorService {
         return object.eClass().getName();
     }
 
-    private static final String[] CHILD_CLASS_SUFFIXES = {
-            "Attribute", "TabularSection", "Command", "Form", "Template", //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$
-            "Dimension", "Resource", "Requisite", "EnumValue", "URLTemplate", "Method", "Operation" //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$ //$NON-NLS-6$ //$NON-NLS-7$
-    };
 
     private MdObject findMdObjectByFqn(Configuration config, String fqn) {
         String[] parts = fqn.split("\\."); //$NON-NLS-1$
-        if (parts.length < 2) {
+        // A dangling odd segment means the FQN is malformed, not that the object is missing.
+        // The previous loop condition (i + 1 < parts.length) walked complete pairs only and
+        // returned whatever had been resolved so far, so Subsystem.Фулфилмент.Инвентаризация
+        // silently answered with the PARENT subsystem and echoed the requested path back as if
+        // it were correct — a wrong answer that looks exactly like a right one.
+        if (!MdObjectFqnResolver.hasCompleteSegmentPairs(parts)) {
             return null;
         }
         MdObject current = findTopLevelObject(config, parts[0], parts[1]);
@@ -173,7 +179,7 @@ public class EdtMetadataInspectorService {
         }
         // Walk nested marker/name pairs, e.g. Document.Foo.Attribute.Bar or Catalog.X.Form.ListForm.
         for (int i = 2; i + 1 < parts.length; i += 2) {
-            current = findChildObject(current, parts[i], parts[i + 1]);
+            current = MdObjectFqnResolver.findNestedChild(current, parts[i], parts[i + 1]);
             if (current == null) {
                 return null;
             }
@@ -205,52 +211,7 @@ public class EdtMetadataInspectorService {
         return null;
     }
 
-    /**
-     * Resolves a nested child object (attribute, tabular section, form, command, template, ...) of
-     * the given parent by a {@code <Marker>.<Name>} pair, so FQNs like
-     * {@code Document.Задача.Attribute.Описание} return the child requisite rather than the owner.
-     */
-    private MdObject findChildObject(MdObject parent, String marker, String childName) {
-        String normalizedMarker = normalizeToken(marker);
-        for (EReference reference : parent.eClass().getEAllReferences()) {
-            if (!reference.isContainment() || !reference.isMany()) {
-                continue;
-            }
-            Object raw = parent.eGet(reference);
-            if (!(raw instanceof Collection<?> collection)) {
-                continue;
-            }
-            for (Object element : collection) {
-                if (!(element instanceof MdObject child) || !childName.equalsIgnoreCase(child.getName())) {
-                    continue;
-                }
-                if (markerMatchesChild(normalizedMarker, reference, child)) {
-                    return child;
-                }
-            }
-        }
-        return null;
-    }
 
-    private boolean markerMatchesChild(String marker, EReference reference, MdObject child) {
-        if (marker.isEmpty()) {
-            return true;
-        }
-        String refName = normalizeToken(reference.getName());
-        if (marker.equals(refName) || marker.equals(singularizeToken(refName))) {
-            return true;
-        }
-        String className = child.eClass().getName();
-        if (marker.equals(normalizeToken(className))) {
-            return true;
-        }
-        for (String suffix : CHILD_CLASS_SUFFIXES) {
-            if (className.endsWith(suffix) && marker.equals(normalizeToken(suffix))) {
-                return true;
-            }
-        }
-        return false;
-    }
 
     private String normalizeToken(String value) {
         if (value == null) {
@@ -268,18 +229,6 @@ public class EdtMetadataInspectorService {
         return sb.toString();
     }
 
-    private String singularizeToken(String value) {
-        if (value == null || value.isBlank()) {
-            return ""; //$NON-NLS-1$
-        }
-        if (value.endsWith("ies")) { //$NON-NLS-1$
-            return value.substring(0, value.length() - 3) + "y"; //$NON-NLS-1$
-        }
-        if (value.endsWith("s") && !value.endsWith("ss")) { //$NON-NLS-1$ //$NON-NLS-2$
-            return value.substring(0, value.length() - 1);
-        }
-        return value;
-    }
 
     private Object formatCollectionValue(Collection<?> collection) {
         if (collection == null || collection.isEmpty()) {

--- a/bundles/com.codepilot1c.core/src/com/codepilot1c/core/edt/metadata/EdtMetadataService.java
+++ b/bundles/com.codepilot1c.core/src/com/codepilot1c/core/edt/metadata/EdtMetadataService.java
@@ -6961,58 +6961,15 @@ public class EdtMetadataService {
         return value instanceof EMap<?, ?> map ? (EMap<String, String>) map : null;
     }
 
+    // Обход вынесен в MdObjectFqnResolver: та же логика жила второй копией в пути чтения
+    // (EdtMetadataInspectorService), где фикс про non-containment Subsystem.subsystems так и не
+    // появился — update_metadata вложенную подсистему находил, edt_metadata_details по тому же
+    // FQN отвечал "Object not found".
     private MdObject findNestedChild(MdObject parent, String marker, String childName) {
-        String normalizedMarker = normalizeToken(marker);
-        for (EStructuralFeature feature : parent.eClass().getEAllStructuralFeatures()) {
-            if (!(feature instanceof EReference reference) || !reference.isContainment() || !reference.isMany()) {
-                continue;
-            }
-            @SuppressWarnings("unchecked")
-            Collection<Object> values = (Collection<Object>) parent.eGet(feature);
-            if (values == null) {
-                continue;
-            }
-            for (Object value : values) {
-                if (!(value instanceof MdObject child)) {
-                    continue;
-                }
-                if (!childName.equalsIgnoreCase(child.getName())) {
-                    continue;
-                }
-                if (matchesMarker(normalizedMarker, feature.getName(), child.eClass().getName())) {
-                    return child;
-                }
-            }
-        }
-        return null;
+        return MdObjectFqnResolver.findNestedChild(parent, marker, childName);
     }
 
-    private boolean matchesMarker(String marker, String featureName, String className) {
-        if (marker == null || marker.isBlank()) {
-            return true;
-        }
-        String normalizedFeature = normalizeToken(featureName);
-        String singularFeature = singularize(normalizedFeature);
-        String normalizedClass = normalizeToken(className);
-        String shortClass = normalizeToken(extractShortClassMarker(className));
-        return marker.equals(normalizedFeature)
-                || marker.equals(singularFeature)
-                || marker.equals(normalizedClass)
-                || marker.equals(shortClass);
-    }
 
-    private String extractShortClassMarker(String className) {
-        String normalized = className != null ? className : ""; //$NON-NLS-1$
-        String[] tails = {
-                "Attribute", "TabularSection", "Command", "Form", "Template", "Dimension", "Resource", "Requisite", "EnumValue" //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$ //$NON-NLS-6$ //$NON-NLS-7$ //$NON-NLS-8$ //$NON-NLS-9$
-        };
-        for (String tail : tails) {
-            if (normalized.endsWith(tail)) {
-                return tail;
-            }
-        }
-        return normalized;
-    }
 
     private MdObject createChildByFactory(MdObject parent, MetadataChildKind kind) {
         String childSuffix = kind.getDisplayName();

--- a/bundles/com.codepilot1c.core/src/com/codepilot1c/core/edt/metadata/MdObjectFqnResolver.java
+++ b/bundles/com.codepilot1c.core/src/com/codepilot1c/core/edt/metadata/MdObjectFqnResolver.java
@@ -1,0 +1,156 @@
+package com.codepilot1c.core.edt.metadata;
+
+import java.util.Collection;
+import java.util.Locale;
+
+import org.eclipse.emf.ecore.EReference;
+import org.eclipse.emf.ecore.EStructuralFeature;
+import org.eclipse.emf.ecore.util.EcoreUtil;
+
+import com._1c.g5.v8.dt.metadata.mdclass.MdObject;
+
+/**
+ * Shared resolution of nested metadata FQN segments, e.g. the {@code Subsystem.Инвентаризация}
+ * tail of {@code Subsystem.Фулфилмент.Subsystem.Инвентаризация}.
+ *
+ * <p>This logic used to live twice: once in the mutation path ({@code EdtMetadataService}) and once
+ * in the inspection path ({@code EdtMetadataInspectorService}). Only the mutation copy learned that
+ * nested subsystems are not plain EMF containment, so {@code update_metadata} could target a nested
+ * subsystem while {@code edt_metadata_details} answered {@code Object not found} for the very same
+ * FQN. Two copies of one rule diverge; one copy cannot.</p>
+ */
+public final class MdObjectFqnResolver {
+
+    private static final String[] CHILD_CLASS_TAILS = {
+            // Union of both former copies. The inspection copy carried three tails the mutation
+            // copy lacked (URLTemplate, Method, Operation); dropping them while merging would have
+            // quietly narrowed FQN resolution for HTTP and web services.
+            "Attribute", "TabularSection", "Command", "Form", "Template", //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$
+            "Dimension", "Resource", "Requisite", "EnumValue", //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+            "URLTemplate", "Method", "Operation" //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+    };
+
+    private MdObjectFqnResolver() {
+        // utility
+    }
+
+    /**
+     * Finds a nested child of {@code parent} by a {@code <Marker>.<Name>} FQN pair.
+     *
+     * <p>Nested metadata hierarchy is not always plain EMF containment. In the EDT metadata model,
+     * nested subsystems ({@code Subsystem.subsystems}) are a NON-containment, resolve-proxies
+     * EReference (verified via bytecode: {@code initEReference isContainment=false,
+     * isResolveProxies=true}) — physically the subsystems are contained by {@code Configuration},
+     * and the tree is expressed through cross-references. A containment-only walker drops that
+     * feature and never finds nested children. A non-containment reference is followed only when
+     * the FQN marker explicitly matches the feature or its type, so arbitrary back-references
+     * (e.g. {@code parentSubsystem}) never produce false matches.</p>
+     *
+     * @return the resolved child, or {@code null} when nothing matches.
+     */
+    public static MdObject findNestedChild(MdObject parent, String marker, String childName) {
+        if (parent == null || childName == null) {
+            return null;
+        }
+        String normalizedMarker = normalizeToken(marker);
+        for (EStructuralFeature feature : parent.eClass().getEAllStructuralFeatures()) {
+            if (!(feature instanceof EReference reference) || !reference.isMany()) {
+                continue;
+            }
+            boolean markerMatchesFeature = matchesMarker(
+                    normalizedMarker, feature.getName(), reference.getEReferenceType().getName());
+            if (!reference.isContainment() && !markerMatchesFeature) {
+                continue;
+            }
+            Object raw = parent.eGet(feature);
+            if (!(raw instanceof Collection<?> values)) {
+                continue;
+            }
+            for (Object value : values) {
+                if (!(value instanceof MdObject child)) {
+                    continue;
+                }
+                // Non-containment references return proxies outside a BM transaction — resolve
+                // them before reading the name (resolveProxies=true for these references).
+                if (child.eIsProxy() || child.getName() == null) {
+                    Object resolved = EcoreUtil.resolve(child, parent);
+                    if (resolved instanceof MdObject resolvedChild) {
+                        child = resolvedChild;
+                    }
+                }
+                if (!childName.equalsIgnoreCase(child.getName())) {
+                    continue;
+                }
+                if (markerMatchesFeature
+                        || matchesMarker(normalizedMarker, feature.getName(), child.eClass().getName())) {
+                    return child;
+                }
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Tells whether FQN segments after the leading {@code <Type>.<Name>} form complete
+     * marker/name pairs.
+     *
+     * <p>A dangling odd segment means the FQN is malformed, not that the object is missing:
+     * {@code Subsystem.Фулфилмент.Инвентаризация} is not a valid EDT FQN. Callers must not silently
+     * fall back to the last resolved ancestor — that answers a question nobody asked and looks
+     * exactly like a correct answer.</p>
+     */
+    public static boolean hasCompleteSegmentPairs(String[] parts) {
+        return parts != null && parts.length >= 2 && (parts.length - 2) % 2 == 0;
+    }
+
+    public static boolean matchesMarker(String marker, String featureName, String className) {
+        if (marker == null || marker.isBlank()) {
+            return true;
+        }
+        String normalizedFeature = normalizeToken(featureName);
+        String singularFeature = singularize(normalizedFeature);
+        String normalizedClass = normalizeToken(className);
+        String shortClass = normalizeToken(extractShortClassMarker(className));
+        return marker.equals(normalizedFeature)
+                || marker.equals(singularFeature)
+                || marker.equals(normalizedClass)
+                || marker.equals(shortClass);
+    }
+
+    public static String normalizeToken(String value) {
+        if (value == null) {
+            return ""; //$NON-NLS-1$
+        }
+        return value
+                .replace("_", "") //$NON-NLS-1$ //$NON-NLS-2$
+                .replace("-", "") //$NON-NLS-1$ //$NON-NLS-2$
+                .replace(" ", "") //$NON-NLS-1$ //$NON-NLS-2$
+                .toLowerCase(Locale.ROOT);
+    }
+
+    public static String singularize(String value) {
+        if (value == null) {
+            return ""; //$NON-NLS-1$
+        }
+        if (value.endsWith("ies")) { //$NON-NLS-1$
+            return value.substring(0, value.length() - 3) + "y"; //$NON-NLS-1$
+        }
+        if (value.endsWith("es")) { //$NON-NLS-1$
+            return value.substring(0, value.length() - 2);
+        }
+        if (value.endsWith("s")) { //$NON-NLS-1$
+            return value.substring(0, value.length() - 1);
+        }
+        return value;
+    }
+
+    private static String extractShortClassMarker(String className) {
+        String normalized = className != null ? className : ""; //$NON-NLS-1$
+        for (String tail : CHILD_CLASS_TAILS) {
+            if (normalized.endsWith(tail)) {
+                return tail;
+            }
+        }
+        return normalized;
+    }
+}


### PR DESCRIPTION
`edt_metadata_details` врёт на вложенных подсистемах двумя разными способами.

**Первый.** По каноническому FQN `Subsystem.Родитель.Subsystem.Вложенная` отвечает
`Object not found`: `findChildObject` обходит только containment-ссылки, а
`Subsystem.subsystems` в модели EDT — non-containment resolve-proxies.

**Второй, и он хуже.** По FQN `Subsystem.Родитель.Вложенная` молча отдаёт **родителя** и
кладёт в поле `path` эхо запрошенного пути. Неверный ответ выглядит как верный.

Причина второго шире подсистем: цикл разбора идёт по условию `i + 1 < parts.length`, то есть
обходит только полные пары `marker`/`name`, а непарный хвост роняет и возвращает последнего
разрешённого предка. Любой FQN с оборванным хвостом — например `Document.X.Attribute` без
имени — отдаёт предка вместо отказа.

При этом путь **записи** обе ситуации отрабатывает верно: `EdtMetadataService.findNestedChild`
умеет non-containment и бросает исключение на непарном хвосте. Логика в кодовой базе уже есть,
но живёт второй копией, и копия в пути чтения про это не знает.

## Что сделано

Обход вынесен в общий `MdObjectFqnResolver`, обе копии переведены на него.

Непарный хвост даёт отдельное сообщение `Malformed FQN` вместо `Object not found` — иначе
кривой запрос и отсутствующий объект неразличимы, а это как раз тот случай, когда разница
важна.

Списки суффиксов классов объединены: у копии чтения было три лишних (`URLTemplate`, `Method`,
`Operation`), и слияние по короткому списку тихо сузило бы резолв HTTP- и web-сервисов.

## Проверка

Живьём на конфигурации с вложенными подсистемами:

- канонический FQN вложенной подсистемы отдаёт **её** — свой uuid, `parentSubsystem`, полный
  состав, — а не родителя;
- FQN с непарным хвостом отбивается как `Malformed FQN`;
- несуществующая вложенная подсистема отличена от кривого FQN;
- обычный вложенный ребёнок `Catalog.X.TabularSection.Y` резолвится по-прежнему;
- путь записи цел: `update_metadata` на вложенной подсистеме пишет в её файл, родитель не
  задет.

Ветка срезана от текущего HEAD, сборка против него зелёная.
